### PR TITLE
Feature/add tooltip to components

### DIFF
--- a/src/components/Avatar/Avatar.stories.js
+++ b/src/components/Avatar/Avatar.stories.js
@@ -20,7 +20,8 @@ export default {
     size: 'normal',
     showName: false,
     src: null,
-    status: null
+    status: null,
+    useTooltip: false
   },
   argTypes: {
     description: {
@@ -73,6 +74,13 @@ export default {
       control: {
         type: 'select',
         options: badgeTypes
+      }
+    },
+    useTooltip: {
+      name: 'useTooltip',
+      description: 'Enable show a tooltip with the username on the bottom',
+      control: {
+        type: 'boolean'
       }
     }
   }
@@ -288,4 +296,32 @@ export const WithStatus = (args) => ({
 WithStatus.args = {
   src: 'https://avatars1.githubusercontent.com/u/7952803?s=400&u=0fd8a3a0721768210fdcedb7607e9ad33af9f7ad&v=4',
   status: 'positive'
+}
+
+WithStatus.parameters = {
+  docs: {
+    description: {
+      story: 'When you set the `status` property, it will show a contracted `SbBadge` component. It is useful to show a user status, like online.'
+    }
+  }
+}
+
+export const WithTooltip = (args) => ({
+  components: { SbAvatar },
+  props: Object.keys(args),
+  template: '<SbAvatar :src="src" :name="name" :use-tooltip="useTooltip" />'
+})
+
+WithTooltip.args = {
+  src: 'https://avatars1.githubusercontent.com/u/7952803?s=400&u=0fd8a3a0721768210fdcedb7607e9ad33af9f7ad&v=4',
+  name: 'John Doe',
+  useTooltip: true
+}
+
+WithTooltip.parameters = {
+  docs: {
+    description: {
+      story: 'When you set the `useTooltip` property, you need to provide a `name` property that should be used for tooltip label. This should not render the user name and description on right'
+    }
+  }
 }

--- a/src/components/Avatar/__tests__/Avatar.spec.js
+++ b/src/components/Avatar/__tests__/Avatar.spec.js
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { waitMs } from '../../../utils/tests-utils'
 import SbAvatar from '..'
 import SbBadge from '../../Badge'
+import SbToolip from '../../Tooltip'
 
 const LOAD_FAILURE_SRC = 'LOAD_FAILURE_SRC'
 const LOAD_SUCCESS_SRC = 'LOAD_SUCCESS_SRC'
@@ -170,6 +171,29 @@ describe('SbAvatar component', () => {
       expect(BadgeComponent.props('type')).toBe('positive')
 
       expect(BadgeComponent.props('contract')).toBe(true)
+    })
+  })
+
+  describe('when pass the useTooltip property', () => {
+    const name = 'John Doe'
+    const wrapper = factory({
+      src: LOAD_SUCCESS_SRC,
+      useTooltip: true,
+      name
+    })
+
+    const ToolipComponent = wrapper.findComponent(SbToolip)
+
+    it('should exists the SbToolip component', () => {
+      expect(ToolipComponent.exists()).toBe(true)
+    })
+
+    it('should have the bottom position as property', () => {
+      expect(ToolipComponent.props('position')).toBe('bottom')
+    })
+
+    it('should have the correct label as property', () => {
+      expect(ToolipComponent.props('label')).toBe(name)
     })
   })
 })

--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -4,6 +4,7 @@ import { canUseDOM, includes } from '../../utils'
 import { isSizeValid, getInitials, generateRandomBgColor } from './utils.js'
 
 import SbBadge from '../Badge'
+import SbTooltip from '../Tooltip'
 
 const positionTypes = ['top', 'bottom']
 
@@ -40,6 +41,10 @@ const SbAvatar = {
     },
     status: {
       type: String
+    },
+    useTooltip: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -144,7 +149,10 @@ const SbAvatar = {
     const renderAvatar = () => {
       if (this.src || this.$slots.default) {
         return h('div', {
-          staticClass: 'sb-avatar__image'
+          staticClass: 'sb-avatar__image',
+          attrs: {
+            ...(this.useTooltip && { tabindex: 0 })
+          }
         }, [
           renderAvatarImage(),
           !!this.status && renderBadgeStatus()
@@ -153,7 +161,10 @@ const SbAvatar = {
 
       if (this.name) {
         return h('div', {
-          staticClass: 'sb-avatar__initials ' + generateRandomBgColor()
+          staticClass: 'sb-avatar__initials ' + generateRandomBgColor(),
+          attrs: {
+            ...(this.useTooltip && { tabindex: 0 })
+          }
         }, [
           h('span', getInitials(this.name)),
           !!this.status && renderBadgeStatus()
@@ -161,11 +172,22 @@ const SbAvatar = {
       }
     }
 
+    if (this.name && this.useTooltip) {
+      return h('div', avatarProps, [
+        h(SbTooltip, {
+          props: {
+            label: this.name,
+            position: 'bottom'
+          }
+        }, [renderAvatar()])
+      ])
+    }
+
     const children = [
       renderAvatar()
     ]
 
-    if (this.showName && this.name) {
+    if (this.showName && this.name && !this.useTooltip) {
       children.push(
         renderTextContainer()
       )

--- a/src/components/AvatarGroup/AvatarGroup.stories.js
+++ b/src/components/AvatarGroup/AvatarGroup.stories.js
@@ -13,9 +13,17 @@ export default {
     }
   },
   args: {
-    size: 'normal'
+    size: 'normal',
+    maxElements: 5
   },
   argTypes: {
+    maxElements: {
+      name: 'maxElements',
+      description: 'Max of `SbAvatar` components to view',
+      control: {
+        type: 'number'
+      }
+    },
     size: {
       name: 'size',
       description: 'Size of the `SbAvatar`',
@@ -107,80 +115,13 @@ WithSizes.parameters = {
   }
 }
 
-export const WithMoreAvatars = () => ({
+export const WithMoreAvatars = args => ({
   components: { SbAvatarGroup, SbAvatar },
+  props: Object.keys(args),
   template: `
   <div>
     <div>
-      <SbAvatarGroup size="large">
-        <SbAvatar
-          src="https://avatars0.githubusercontent.com/u/20342656?s=460&u=1f62c95c10543861ad74b58a3c03cd774e7a4fa4&v=4"
-        />
-
-        <SbAvatar name="John Doe" />
-
-        <SbAvatar
-          src="https://avatars0.githubusercontent.com/u/20342656?s=460&u=1f62c95c10543861ad74b58a3c03cd774e7a4fa4&v=4"
-        />
-
-        <SbAvatar
-          src="https://avatars0.githubusercontent.com/u/20342656?s=460&u=1f62c95c10543861ad74b58a3c03cd774e7a4fa4&v=4"
-        />
-
-        <SbAvatar
-          src="https://avatars0.githubusercontent.com/u/20342656?s=460&u=1f62c95c10543861ad74b58a3c03cd774e7a4fa4&v=4"
-        />
-
-        <SbAvatar name="John Doe" />
-
-        <SbAvatar
-          src="https://avatars1.githubusercontent.com/u/7952803?s=400&u=0fd8a3a0721768210fdcedb7607e9ad33af9f7ad&v=4"
-          name="Dominik Angerer"
-        />
-
-        <SbAvatar
-          src="https://avatars1.githubusercontent.com/u/160495?s=460&u=b88ece40883d2e9716e833f6a3c78c56ca3eb14f&v=4"
-          name="Alexander Feiglstorfer"
-        />
-      </SbAvatarGroup>
-    </div>
-
-    <div>
-      <SbAvatarGroup>
-        <SbAvatar
-          src="https://avatars0.githubusercontent.com/u/20342656?s=460&u=1f62c95c10543861ad74b58a3c03cd774e7a4fa4&v=4"
-        />
-
-        <SbAvatar name="John Doe" />
-
-        <SbAvatar
-          src="https://avatars0.githubusercontent.com/u/20342656?s=460&u=1f62c95c10543861ad74b58a3c03cd774e7a4fa4&v=4"
-        />
-
-        <SbAvatar
-          src="https://avatars0.githubusercontent.com/u/20342656?s=460&u=1f62c95c10543861ad74b58a3c03cd774e7a4fa4&v=4"
-        />
-
-        <SbAvatar
-          src="https://avatars0.githubusercontent.com/u/20342656?s=460&u=1f62c95c10543861ad74b58a3c03cd774e7a4fa4&v=4"
-        />
-
-        <SbAvatar name="John Doe" />
-
-        <SbAvatar
-          src="https://avatars1.githubusercontent.com/u/7952803?s=400&u=0fd8a3a0721768210fdcedb7607e9ad33af9f7ad&v=4"
-          name="Dominik Angerer"
-        />
-
-        <SbAvatar
-          src="https://avatars1.githubusercontent.com/u/160495?s=460&u=b88ece40883d2e9716e833f6a3c78c56ca3eb14f&v=4"
-          name="Alexander Feiglstorfer"
-        />
-      </SbAvatarGroup>
-    </div>
-
-    <div>
-      <SbAvatarGroup size="small">
+      <SbAvatarGroup v-bind="{ size, maxElements }">
         <SbAvatar
           src="https://avatars0.githubusercontent.com/u/20342656?s=460&u=1f62c95c10543861ad74b58a3c03cd774e7a4fa4&v=4"
         />
@@ -219,7 +160,7 @@ export const WithMoreAvatars = () => ({
 WithMoreAvatars.parameters = {
   docs: {
     description: {
-      story: 'When you have more than **6** `SbAvatar` components, it will be render a placeholder as last element indicating how many more components are there'
+      story: 'When you have more than **5** `SbAvatar` components, it will be render a placeholder as last element indicating how many more components are there. The number of max elements can be changed with the `maxElements` property'
     }
   }
 }

--- a/src/components/AvatarGroup/AvatarGroup.stories.js
+++ b/src/components/AvatarGroup/AvatarGroup.stories.js
@@ -34,14 +34,17 @@ export const Default = (args) => ({
   <SbAvatarGroup :size="size">
     <SbAvatar
       src="https://avatars0.githubusercontent.com/u/20342656?s=460&u=1f62c95c10543861ad74b58a3c03cd774e7a4fa4&v=4"
+      name="John Doe"
     />
 
     <SbAvatar
       src="https://avatars0.githubusercontent.com/u/20342656?s=460&u=1f62c95c10543861ad74b58a3c03cd774e7a4fa4&v=4"
+      name="Kobe Bryant"
     />
 
     <SbAvatar
       src="https://avatars0.githubusercontent.com/u/20342656?s=460&u=1f62c95c10543861ad74b58a3c03cd774e7a4fa4&v=4"
+      name="Elvis Presley"
     />
   </SbAvatarGroup>
   `

--- a/src/components/AvatarGroup/__tests__/AvatarGroup.spec.js
+++ b/src/components/AvatarGroup/__tests__/AvatarGroup.spec.js
@@ -20,7 +20,7 @@ const factory = (template, propsData = {}) => {
 }
 
 describe('SbAvatarGroup component', () => {
-  it('should render a list of Avatars when it has less than six users', () => {
+  it('should render a list of Avatars when it has less than five users', () => {
     const template = `
       <SbAvatarGroup>
         <SbAvatar src="LOAD_SUCCESS_SRC" />
@@ -48,34 +48,60 @@ describe('SbAvatarGroup component', () => {
     })
   })
 
-  describe('when there are more than six Avatar components', () => {
-    const template = `
-      <SbAvatarGroup size="large">
-        <SbAvatar src="LOAD_SUCCESS_SRC" />
-        <SbAvatar src="LOAD_SUCCESS_SRC" />
-        <SbAvatar src="LOAD_SUCCESS_SRC" />
-        <SbAvatar src="LOAD_SUCCESS_SRC" />
-        <SbAvatar src="LOAD_SUCCESS_SRC" />
-        <SbAvatar src="LOAD_SUCCESS_SRC" />
-        <SbAvatar src="LOAD_SUCCESS_SRC" />
-        <SbAvatar src="LOAD_SUCCESS_SRC" />
-        <SbAvatar src="LOAD_SUCCESS_SRC" />
-      </SbAvatarGroup>
-    `
-    const wrappers = factory(template)
+  describe('when there are more than five Avatar components', () => {
+    const wrapper = {
+      components: {
+        SbAvatar,
+        SbAvatarGroup
+      },
+      props: {
+        size: 'large',
+        maxElements: 5
+      },
+      template: `
+        <SbAvatarGroup :size="size" :max-elements="maxElements">
+          <SbAvatar src="LOAD_SUCCESS_SRC" />
+          <SbAvatar src="LOAD_SUCCESS_SRC" />
+          <SbAvatar src="LOAD_SUCCESS_SRC" />
+          <SbAvatar src="LOAD_SUCCESS_SRC" />
+          <SbAvatar src="LOAD_SUCCESS_SRC" />
+          <SbAvatar src="LOAD_SUCCESS_SRC" />
+          <SbAvatar src="LOAD_SUCCESS_SRC" />
+          <SbAvatar src="LOAD_SUCCESS_SRC" />
+          <SbAvatar src="LOAD_SUCCESS_SRC" />
+        </SbAvatarGroup>
+      `
+    }
+    const wrappers = mount(wrapper)
 
-    it('should render a list of six Avatars', () => {
-      expect(wrappers.findAll('.sb-avatar-group > .sb-avatar').length).toBe(6)
+    it('should render a list of five Avatars', () => {
+      expect(wrappers.findAll('.sb-avatar-group > .sb-avatar').length).toBe(5)
     })
 
     it('should render, as the last element, the MoreAvatar component with +n text', () => {
       expect(wrappers.findAllComponents(MoreAvatar).length).toBe(1)
-      expect(wrappers.findComponent(MoreAvatar).text()).toBe('+3')
+      expect(wrappers.findComponent(MoreAvatar).text()).toBe('+4')
     })
 
     it('should render the MoreAvatars component with the children', () => {
       const moreAvatars = wrappers.findComponent(MoreAvatars)
-      expect(moreAvatars.findAll('.sb-avatar').length).toBe(3)
+      expect(moreAvatars.findAll('.sb-avatar').length).toBe(4)
+    })
+
+    it('should render the correct SbAvatar when changes the maxElements property', async () => {
+      await wrappers.setProps({
+        maxElements: 7
+      })
+
+      expect(
+        wrappers.findAll('.sb-avatar-group > .sb-avatar').length
+      ).toBe(7)
+      expect(
+        wrappers.findComponent(MoreAvatar).text()
+      ).toBe('+2')
+      expect(
+        wrappers.findComponent(MoreAvatars).findAll('.sb-avatar').length
+      ).toBe(2)
     })
   })
 })

--- a/src/components/AvatarGroup/avatar-group.scss
+++ b/src/components/AvatarGroup/avatar-group.scss
@@ -11,6 +11,7 @@
 
   > .sb-avatar {
     margin-left: -15px;
+    z-index: 2;
     cursor: pointer;
     
     .sb-avatar__image,
@@ -23,6 +24,7 @@
   }
 
   &__more {
+    z-index: 1;
     @include avatarGroupItem;
     margin-left: -15px;
     cursor: pointer;

--- a/src/components/AvatarGroup/index.js
+++ b/src/components/AvatarGroup/index.js
@@ -82,6 +82,10 @@ const SbAvatarGroup = {
   name: 'AvatarGroup',
 
   props: {
+    maxElements: {
+      type: Number,
+      default: 5
+    },
     size: {
       type: String,
       validator: isSizeValid
@@ -111,7 +115,7 @@ const SbAvatarGroup = {
     const sizeClass = this.size ? `sb-avatar-group--${this.size}` : null
 
     const childrenCount = children.length
-    const maxElements = 6
+    const maxElements = this.maxElements || 5
 
     const data = children.map((element, index) => {
       if (maxElements && index < maxElements) {

--- a/src/components/AvatarGroup/index.js
+++ b/src/components/AvatarGroup/index.js
@@ -84,7 +84,8 @@ const SbAvatarGroup = {
       if (maxElements && index < maxElements) {
         element.componentOptions.propsData = {
           ...element.componentOptions.propsData,
-          ...props
+          ...props,
+          useTooltip: true
         }
 
         return element

--- a/src/components/Breadcrumbs/BreadcrumItem.js
+++ b/src/components/Breadcrumbs/BreadcrumItem.js
@@ -1,3 +1,5 @@
+import SbTooltip from '../Tooltip'
+
 /**
  * @method getLabelTruncated
  * @param  {string} label
@@ -96,22 +98,35 @@ const SbBreadcrumbItem = {
       }
     }
 
-    const renderChildren = () => {
+    const renderLabel = () => {
       if (!isActive) {
+        return h(SbBreadcrumbLink, {
+          props: {
+            title,
+            href,
+            to,
+            as,
+            label: labelFormated
+          }
+        })
+      }
+
+      return labelFormated
+    }
+
+    const renderChildren = () => {
+      if (isTruncated) {
         return [
-          h(SbBreadcrumbLink, {
+          h(SbTooltip, {
             props: {
-              title,
-              href,
-              to,
-              as,
-              label: labelFormated
+              position: 'bottom',
+              label
             }
-          })
+          }, [renderLabel()])
         ]
       }
 
-      return [labelFormated]
+      return [renderLabel()]
     }
 
     return h('li', breadcrumbsItemProps, renderChildren())

--- a/src/components/Breadcrumbs/__tests__/BreadcrumbItem.spec.js
+++ b/src/components/Breadcrumbs/__tests__/BreadcrumbItem.spec.js
@@ -1,5 +1,6 @@
 import { mount, RouterLinkStub, shallowMount } from '@vue/test-utils'
 import { SbBreadcrumbItem, SbBreadcrumbLink } from '../BreadcrumItem'
+import SbTooltip from '../../Tooltip'
 
 const factory = (propsData = {}) => {
   return mount(SbBreadcrumbItem, {
@@ -34,17 +35,27 @@ describe('SbBreadcrumbItem component', () => {
   })
 
   describe('when render a long label', () => {
+    const title = 'A long title that should be render correctly'
+    const label = 'A long label to test'
     const wrapper = factory({
       href: '/test-link',
-      label: 'A long label to test',
-      title: 'A long title that should be render correctly'
+      label,
+      title
     })
 
     it('should render the first 13 letters', () => {
       const linkTag = wrapper.find('a')
       expect(linkTag.attributes('href')).toBe('/test-link')
-      expect(linkTag.attributes('title')).toBe('A long title that should be render correctly')
+      expect(linkTag.attributes('title')).toBe(title)
       expect(linkTag.text()).toBe('A long label ...')
+    })
+
+    it('should render a tooltip with the long label at the bottom position', () => {
+      const SbTooltipComponent = wrapper.findComponent(SbTooltip)
+
+      expect(SbTooltipComponent.exists()).toBe(true)
+      expect(SbTooltipComponent.props('label')).toBe(label)
+      expect(SbTooltipComponent.props('position')).toBe('bottom')
     })
   })
 

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -61,6 +61,7 @@ export default {
     isFullWidth: false,
     isRounded: false,
     icon: null,
+    iconDescription: null,
     iconRight: null,
     hasIconOnly: false,
     label: 'Default',
@@ -73,6 +74,13 @@ export default {
       description: 'Disable button',
       control: {
         type: 'boolean'
+      }
+    },
+    iconDescription: {
+      name: 'iconDescription',
+      description: 'Description to Icon when the `SbButton` has the `hasIconOnly` property setted to true',
+      control: {
+        type: 'text'
       }
     },
     iconRight: {
@@ -303,6 +311,7 @@ export const JustIcons = args => ({
       :icon="icon"
       :is-loading="isLoading"
       :is-disabled="isDisabled"
+      :icon-description="iconDescription"
       is-rounded
       has-icon-only
     />
@@ -311,7 +320,8 @@ export const JustIcons = args => ({
 
 JustIcons.args = {
   icon: 'plus',
-  isRounded: false
+  isRounded: false,
+  iconDescription: 'Hey! I have a description!'
 }
 
 JustIcons.parameters = {

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,5 +1,6 @@
 // other components
 import SbIcon from '../Icon'
+import SbTooltip from '../Tooltip'
 
 // styles
 import './button.scss'
@@ -24,6 +25,10 @@ const SbButton = {
       default: null
     },
     iconRight: {
+      type: String,
+      default: null
+    },
+    iconDescription: {
       type: String,
       default: null
     },
@@ -108,6 +113,15 @@ const SbButton = {
       !this.hasIconOnly && renderLabel(),
       this.iconRight && renderIcon(this.iconRight)
     ]
+
+    if (this.hasIconOnly && this.iconDescription) {
+      return h(SbTooltip, {
+        props: {
+          label: this.iconDescription,
+          position: 'bottom'
+        }
+      }, [renderButton(content)])
+    }
 
     return renderButton(content)
   }

--- a/src/components/GroupButton/GroupButton.stories.js
+++ b/src/components/GroupButton/GroupButton.stories.js
@@ -86,9 +86,9 @@ export const JustIcons = args => ({
   props: Object.keys(args),
   template: `
     <SbGroupButton v-bind="{ size, type, hasSpaces }">
-      <SbButton has-icon-only icon="calendar" />
-      <SbButton has-icon-only icon="plus" />
-      <SbButton has-icon-only icon="overflow-menu-vertic" />
+      <SbButton has-icon-only icon="calendar" iconDescription="Calendar Icon" />
+      <SbButton has-icon-only icon="plus" iconDescription="Plus Icon" />
+      <SbButton has-icon-only icon="overflow-menu-vertic" iconDescription="Overflow Icon" />
     </SbGroupButton>
   `
 })

--- a/src/components/Tooltip/__tests__/Tooltip.spec.js
+++ b/src/components/Tooltip/__tests__/Tooltip.spec.js
@@ -1,36 +1,104 @@
 import { mount } from '@vue/test-utils'
 import SbTooltip from '..'
 import SbButton from '../../Button'
+import SbIcon from '../../Icon'
 
-const factory = (template, additionalComponents = {}) => {
+const factory = (
+  template,
+  additionalComponents = {},
+  additionalInformation = {}
+) => {
   const WrapperComponent = {
     components: { SbTooltip, ...additionalComponents },
-    template
+    template,
+    ...additionalInformation
   }
 
   return mount(WrapperComponent)
 }
 
 describe('test SbTooltip component', () => {
-  describe('when render a simple tooltip with a label to a SbButton component', () => {
+  describe('when using along with a SbButton component', () => {
     const label = 'This is a label to SbButton'
     const buttonText = 'Hover Me!'
     const template = `
       <SbTooltip label="${label}">
-        <SbButton> ${buttonText} </SbButton>
+        <SbButton is-full-width icon="close" @click="onClick">
+          ${buttonText}
+        </SbButton>
+      </SbTooltip>
+    `
+
+    const onClick = jest.fn()
+    const onFocus = jest.fn()
+    const additionalInfo = {
+      methods: {
+        onClick,
+        onFocus
+      }
+    }
+
+    const wrapper = factory(template, { SbButton }, additionalInfo)
+    const ButtonComponent = wrapper.findComponent(SbButton)
+    const IconComponent = wrapper.findComponent(SbIcon)
+
+    it('should render the tooltip label with correct text', () => {
+      expect(wrapper.find('.sb-tooltip__label').text()).toBe(label)
+    })
+
+    it('should render the SbButton component', () => {
+      expect(ButtonComponent.exists()).toBe(true)
+      expect(ButtonComponent.text()).toBe(buttonText)
+    })
+
+    it('should render the SbButton with isFullWidth', () => {
+      expect(ButtonComponent.props('isFullWidth')).toBe(true)
+    })
+
+    it('should render with icon close', () => {
+      expect(ButtonComponent.props('icon')).toBe('close')
+    })
+
+    it('should allow clicks', async () => {
+      await ButtonComponent.trigger('click')
+      expect(onClick).toHaveBeenCalled()
+    })
+
+    it('should have the same id and aria-describedby in the SbButton', () => {
+      const id = ButtonComponent.attributes('aria-describedby')
+      expect(wrapper.find(`#${id}`).exists()).toBe(true)
+    })
+
+    it('should exists the SbIcon component', () => {
+      expect(IconComponent.exists()).toBe(true)
+    })
+
+    it('should render the SbIcon with close name', () => {
+      expect(IconComponent.props('name')).toBe('close')
+    })
+  })
+
+  describe('when using along with texted elements', () => {
+    const label = 'This is a label to a texted element'
+    const template = `
+      <SbTooltip label="${label}">
+        Hover me! I'm just a text
       </SbTooltip>
     `
 
     const wrapper = factory(template, { SbButton })
 
-    it('should render the SbButton component', () => {
-      const ButtonComponent = wrapper.findComponent(SbButton)
-      expect(ButtonComponent.exists()).toBe(true)
-      expect(ButtonComponent.text()).toBe(buttonText)
-    })
-
     it('should render the tooltip label with correct text', () => {
       expect(wrapper.find('.sb-tooltip__label').text()).toBe(label)
+    })
+
+    it('should wrap the element with a span', () => {
+      expect(wrapper.find('span.sb-tooltip').exists()).toBe(true)
+    })
+
+    it('should have the same id and aria-describedby in the container', () => {
+      const id = wrapper.attributes('aria-describedby')
+      expect(wrapper.find(`#${id}`).exists()).toBe(true)
     })
   })
 


### PR DESCRIPTION
This PR adds the `SbTooltip` components to:
* `SbButton`: when the `iconDescription` and `hasIconOnly` properties are defined
* `SbBreadcrumbs`: when the breadcrumb label is too long
* `SbAvatar`: when using along with `SbAvatarGroup`.