### PR TITLE
fix forward of listeners and other properties in tooltip

### DIFF
--- a/src/components/Tooltip/__tests__/Tooltip.spec.js
+++ b/src/components/Tooltip/__tests__/Tooltip.spec.js
@@ -116,4 +116,106 @@ describe('test SbTooltip component', () => {
       expect(wrapper.classes('sb-tooltip--right')).toBe(true)
     })
   })
+
+  describe('when using along with a button component', () => {
+    const label = 'This is a label to SbButton'
+    const buttonText = 'Hover Me!'
+    const template = `
+      <SbTooltip label="${label}">
+        <button aria-label="Test label" type="submit" @click="onClick">
+          ${buttonText}
+        </button>
+      </SbTooltip>
+    `
+
+    const onClick = jest.fn()
+    const additionalInfo = {
+      methods: {
+        onClick
+      }
+    }
+
+    const wrapper = factory(template, {}, additionalInfo)
+    const ButtonComponent = wrapper.find('button')
+
+    it('should emits the click event when clicks on button', async () => {
+      await ButtonComponent.trigger('click')
+
+      expect(onClick).toBeCalled()
+    })
+
+    it('should the button has the correct attributes', () => {
+      expect(ButtonComponent.attributes('aria-label')).toBe('Test label')
+      expect(ButtonComponent.attributes('type')).toBe('submit')
+    })
+  })
+
+  describe('when test the navigation', () => {
+    const label = 'This is a label to SbButton'
+    const buttonText = 'Hover Me!'
+    const template = `
+      <SbTooltip label="${label}">
+        <button aria-label="Test label" type="submit" @click="onClick">
+          ${buttonText}
+        </button>
+      </SbTooltip>
+    `
+
+    const onClick = jest.fn()
+    const additionalInfo = {
+      methods: {
+        onClick
+      }
+    }
+
+    const wrapper = factory(template, {}, additionalInfo)
+    const ButtonComponent = wrapper.find('button')
+    const TooltipComponent = wrapper.find('[role="tooltip"]')
+
+    it('should perform the show on focus hide on blur', async () => {
+      expect(
+        TooltipComponent.attributes('aria-hidden')
+      ).toBe('true')
+
+      ButtonComponent.element.focus()
+
+      await wrapper.vm.$nextTick()
+
+      expect(
+        TooltipComponent.attributes('aria-hidden')
+      ).toBe('false')
+
+      ButtonComponent.element.blur()
+
+      await wrapper.vm.$nextTick()
+
+      expect(
+        TooltipComponent.attributes('aria-hidden')
+      ).toBe('true')
+    })
+
+    it('should perform the show on focus hide on escape key is pressed', async () => {
+      expect(
+        TooltipComponent.attributes('aria-hidden')
+      ).toBe('true')
+
+      ButtonComponent.element.focus()
+
+      await wrapper.vm.$nextTick()
+
+      expect(
+        TooltipComponent.attributes('aria-hidden')
+      ).toBe('false')
+
+      await ButtonComponent.trigger('keydown', {
+        key: 'Escape'
+      })
+
+      await wrapper.vm.$nextTick()
+
+      expect(
+        TooltipComponent.attributes('aria-hidden')
+      ).toBe('true')
+    })
+  })
 })

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -46,12 +46,24 @@ export default {
   },
 
   methods: {
+    /**
+     * shows the tooltip
+     */
     showTooltip () {
       this.isVisibleTooltip = true
     },
+
+    /**
+     * hides the tooltip
+     */
     hideTooltip () {
       this.isVisibleTooltip = false
     },
+
+    /**
+     * handles with the keydown event to close the tooltip when esc key is pressed
+     * @param  {Event} event
+     */
     handleKeydown (event) {
       if (event.key === 'Escape') {
         this.hideTooltip()
@@ -93,8 +105,9 @@ export default {
         }, childrenElement.componentOptions.children)
       }
 
+      const childrenData = childrenElement.data || {}
       return h(childrenElement.tag, {
-        ...(childrenElement.data || {}),
+        ...childrenData,
         attrs: {
           ...(childrenElement.data ? childrenElement.data.attrs : {}),
           'aria-describedby': id
@@ -104,7 +117,8 @@ export default {
           blur: this.hideTooltip,
           mouseenter: this.showTooltip,
           mouseleave: this.hideTooltip,
-          keydown: this.handleKeydown
+          keydown: this.handleKeydown,
+          ...(childrenData.on || {})
         }
       }, childrenElement.children)
     }


### PR DESCRIPTION
This PR fixes a bug in tooltip component when it wrappers a clickable element, for example, and, it's not possible to clicks in the element because the listeners is not forward by the tooltip component.