### PR TITLE
Update component: sb-button

### DIFF
--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -8,13 +8,13 @@ const ButtonTemplate = (args) => ({
   template: `
     <div>
       <SbButton
-        :type="type"
+        :color-palette="colorPalette"
         :label="label"
         :size="size"
       />
 
       <SbButton
-        :type="type"
+        :color-palette="colorPalette"
         :is-disabled="isDisabled"
         :icon="icon"
         :label="label"
@@ -22,7 +22,7 @@ const ButtonTemplate = (args) => ({
       />
 
       <SbButton
-        :type="type"
+        :color-palette="colorPalette"
         :is-disabled="isDisabled"
         :icon-right="iconRight"
         :label="label"
@@ -30,7 +30,7 @@ const ButtonTemplate = (args) => ({
       />
 
       <SbButton
-        :type="type"
+        :color-palette="colorPalette"
         :label="label"
         :is-loading="isLoading"
         isDisabled
@@ -38,7 +38,7 @@ const ButtonTemplate = (args) => ({
       />
 
       <SbButton
-        :type="type"
+        :color-palette="colorPalette"
         is-loading
         :is-disabled="isDisabled"
         :size="size"
@@ -69,7 +69,7 @@ export default {
     hasIconOnly: false,
     label: 'Default',
     size: null,
-    type: 'primary',
+    colorPalette: 'primary',
     tooltipPosition: 'bottom',
   },
   argTypes: {
@@ -145,9 +145,9 @@ export default {
         options: ['small', 'normal', 'large'],
       },
     },
-    type: {
-      name: 'type',
-      description: '`SbButton` type',
+    colorPalette: {
+      name: 'colorPalette',
+      description: '`SbButton` colorPalette',
       control: {
         type: 'select',
         options: ['primary', 'secondary', 'ghost', 'danger'],
@@ -178,7 +178,7 @@ export const Default = (args) => ({
       :has-icon-only="hasIconOnly"
       :label="label"
       :size="size"
-      :type="type"
+      :color-palette="colorPalette"
       :tooltip-position="tooltipPosition"
     />
   `,
@@ -204,7 +204,7 @@ Primary.parameters = {
 export const Secondary = ButtonTemplate.bind({})
 
 Secondary.args = {
-  type: 'secondary',
+  colorPalette: 'secondary',
   label: 'Secondary',
   icon: 'checkmark',
   iconRight: 'calendar',
@@ -223,7 +223,7 @@ export const Ghost = ButtonTemplate.bind({})
 
 Ghost.args = {
   label: 'Ghost',
-  type: 'ghost',
+  colorPalette: 'ghost',
   icon: 'checkmark',
   iconRight: 'calendar',
 }
@@ -241,7 +241,7 @@ export const Danger = ButtonTemplate.bind({})
 
 Danger.args = {
   label: 'Danger',
-  type: 'danger',
+  colorPalette: 'danger',
   icon: 'close',
   iconRight: 'close',
 }
@@ -258,9 +258,9 @@ export const Sizes = (args) => ({
   components: { SbButton },
   props: Object.keys(args),
   template: `<div>
-    <SbButton label="Small" size="small" :type="type" />
-    <SbButton label="Default" :type="type" />
-    <SbButton label="Large" size="large" :type="type" />
+    <SbButton label="Small" size="small" :color-palette="colorPalette" />
+    <SbButton label="Default" :color-palette="colorPalette" />
+    <SbButton label="Large" size="large" :color-palette="colorPalette" />
   </div>`,
 })
 
@@ -278,7 +278,7 @@ export const FullWidth = (args) => ({
   props: Object.keys(args),
   template: `<div style="max-width: 500px;">
     <SbButton
-      :type="type"
+      :color-palette="colorPalette"
       :is-loading="isLoading"
       :is-disabled="isDisabled"
       :size="size"
@@ -307,7 +307,7 @@ export const JustIcons = (args) => ({
   props: Object.keys(args),
   template: `<div style="max-width: 500px;">
     <SbButton
-      type="primary"
+      colorPalette="primary"
       :size="size"
       :icon="icon"
       :is-loading="isLoading"
@@ -316,7 +316,7 @@ export const JustIcons = (args) => ({
     />
 
     <SbButton
-      type="secondary"
+      colorPalette="secondary"
       :size="size"
       :icon="icon"
       :is-loading="isLoading"
@@ -325,7 +325,7 @@ export const JustIcons = (args) => ({
     />
 
     <SbButton
-      type="ghost"
+      colorPalette="ghost"
       :size="size"
       :icon="icon"
       :is-loading="isLoading"
@@ -358,7 +358,7 @@ export const InlineLabel = (args) => ({
   props: Object.keys(args),
   template: `<div style="max-width: 500px;">
     <SbButton
-      :type="type"
+      :color-palette="colorPalette"
       :is-loading="isLoading"
       :is-disabled="isDisabled"
       :size="size"
@@ -391,14 +391,14 @@ export const LoadingButton = (args) => ({
       :is-loading="isLoading"
       :is-disabled="isDisabled"
       :size="size"
-      :type="type"
+      :color-palette="colorPalette"
     />`,
 })
 
 LoadingButton.args = ButtonTemplate.bind({})
 
 LoadingButton.args = {
-  type: 'primary',
+  colorPalette: 'primary',
   isLoading: true,
 }
 

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -9,14 +9,14 @@ const ButtonTemplate = (args) => ({
   template: `
     <div>
       <SbButton
-        :color-palette="colorPalette"
+        :variant="variant"
         :label="label"
         :size="size"
         :type="type"
       />
 
       <SbButton
-        :color-palette="colorPalette"
+        :variant="variant"
         :is-disabled="isDisabled"
         :icon="icon"
         :label="label"
@@ -25,7 +25,7 @@ const ButtonTemplate = (args) => ({
       />
 
       <SbButton
-        :color-palette="colorPalette"
+        :variant="variant"
         :is-disabled="isDisabled"
         :icon-right="iconRight"
         :label="label"
@@ -34,7 +34,7 @@ const ButtonTemplate = (args) => ({
       />
 
       <SbButton
-        :color-palette="colorPalette"
+        :variant="variant"
         :label="label"
         :is-loading="isLoading"
         isDisabled
@@ -43,7 +43,7 @@ const ButtonTemplate = (args) => ({
       />
 
       <SbButton
-        :color-palette="colorPalette"
+        :variant="variant"
         is-loading
         :is-disabled="isDisabled"
         :size="size"
@@ -75,7 +75,7 @@ export default {
     hasIconOnly: false,
     label: 'Default',
     size: null,
-    colorPalette: 'primary',
+    variant: 'primary',
     tooltipPosition: 'bottom',
     type: null,
   },
@@ -152,9 +152,9 @@ export default {
         options: ['small', 'normal', 'large'],
       },
     },
-    colorPalette: {
-      name: 'colorPalette',
-      description: '`SbButton` colorPalette',
+    variant: {
+      name: 'variant',
+      description: '`SbButton` variant',
       control: {
         type: 'select',
         options: ['primary', 'secondary', 'ghost', 'danger'],
@@ -194,7 +194,7 @@ export const Default = (args) => ({
       :has-icon-only="hasIconOnly"
       :label="label"
       :size="size"
-      :color-palette="colorPalette"
+      :variant="variant"
       :tooltip-position="tooltipPosition"
       :type="type"
     />
@@ -221,7 +221,7 @@ Primary.parameters = {
 export const Secondary = ButtonTemplate.bind({})
 
 Secondary.args = {
-  colorPalette: 'secondary',
+  variant: 'secondary',
   label: 'Secondary',
   icon: 'checkmark',
   iconRight: 'calendar',
@@ -240,7 +240,7 @@ export const Ghost = ButtonTemplate.bind({})
 
 Ghost.args = {
   label: 'Ghost',
-  colorPalette: 'ghost',
+  variant: 'ghost',
   icon: 'checkmark',
   iconRight: 'calendar',
 }
@@ -258,7 +258,7 @@ export const Danger = ButtonTemplate.bind({})
 
 Danger.args = {
   label: 'Danger',
-  colorPalette: 'danger',
+  variant: 'danger',
   icon: 'close',
   iconRight: 'close',
 }
@@ -275,9 +275,9 @@ export const Sizes = (args) => ({
   components: { SbButton },
   props: Object.keys(args),
   template: `<div>
-    <SbButton label="Small" size="small" :color-palette="colorPalette" />
-    <SbButton label="Default" :color-palette="colorPalette" />
-    <SbButton label="Large" size="large" :color-palette="colorPalette" />
+    <SbButton label="Small" size="small" :variant="variant" />
+    <SbButton label="Default" :variant="variant" />
+    <SbButton label="Large" size="large" :variant="variant" />
   </div>`,
 })
 
@@ -295,7 +295,7 @@ export const FullWidth = (args) => ({
   props: Object.keys(args),
   template: `<div style="max-width: 500px;">
     <SbButton
-      :color-palette="colorPalette"
+      :variant="variant"
       :is-loading="isLoading"
       :is-disabled="isDisabled"
       :size="size"
@@ -325,7 +325,7 @@ export const JustIcons = (args) => ({
   props: Object.keys(args),
   template: `<div style="max-width: 500px;">
     <SbButton
-      colorPalette="primary"
+      variant="primary"
       :size="size"
       :icon="icon"
       :is-loading="isLoading"
@@ -335,7 +335,7 @@ export const JustIcons = (args) => ({
     />
 
     <SbButton
-      colorPalette="secondary"
+      variant="secondary"
       :size="size"
       :icon="icon"
       :is-loading="isLoading"
@@ -345,7 +345,7 @@ export const JustIcons = (args) => ({
     />
 
     <SbButton
-      colorPalette="ghost"
+      variant="ghost"
       :size="size"
       :icon="icon"
       :is-loading="isLoading"
@@ -379,7 +379,7 @@ export const InlineLabel = (args) => ({
   props: Object.keys(args),
   template: `<div style="max-width: 500px;">
     <SbButton
-      :color-palette="colorPalette"
+      :variant="variant"
       :is-loading="isLoading"
       :is-disabled="isDisabled"
       :size="size"
@@ -413,7 +413,7 @@ export const LoadingButton = (args) => ({
       :is-loading="isLoading"
       :is-disabled="isDisabled"
       :size="size"
-      :color-palette="colorPalette"
+      :variant="variant"
       :type="type"
     />`,
 })
@@ -421,7 +421,7 @@ export const LoadingButton = (args) => ({
 LoadingButton.args = ButtonTemplate.bind({})
 
 LoadingButton.args = {
-  colorPalette: 'primary',
+  variant: 'primary',
   isLoading: true,
 }
 

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -1,6 +1,7 @@
 import SbButton from './index'
 
 import { availablePositions as availableTooltipPositions } from '../Tooltip/lib'
+import { availableButtonsTypes } from './lib'
 
 const ButtonTemplate = (args) => ({
   components: { SbButton },
@@ -11,6 +12,7 @@ const ButtonTemplate = (args) => ({
         :color-palette="colorPalette"
         :label="label"
         :size="size"
+        :type="type"
       />
 
       <SbButton
@@ -19,6 +21,7 @@ const ButtonTemplate = (args) => ({
         :icon="icon"
         :label="label"
         :size="size"
+        :type="type"
       />
 
       <SbButton
@@ -27,6 +30,7 @@ const ButtonTemplate = (args) => ({
         :icon-right="iconRight"
         :label="label"
         :size="size"
+        :type="type"
       />
 
       <SbButton
@@ -35,6 +39,7 @@ const ButtonTemplate = (args) => ({
         :is-loading="isLoading"
         isDisabled
         :size="size"
+        :type="type"
       />
 
       <SbButton
@@ -42,6 +47,7 @@ const ButtonTemplate = (args) => ({
         is-loading
         :is-disabled="isDisabled"
         :size="size"
+        :type="type"
       />
     </div>
   `,
@@ -71,6 +77,7 @@ export default {
     size: null,
     colorPalette: 'primary',
     tooltipPosition: 'bottom',
+    type: null,
   },
   argTypes: {
     isDisabled: {
@@ -161,6 +168,15 @@ export default {
         options: [...availableTooltipPositions],
       },
     },
+    type: {
+      name: 'type',
+      description:
+        'The `type` attribute specifies the `type` of button, the available options are **button**, **submit**, **reset**, the default value is null.',
+      control: {
+        type: 'select',
+        options: [...availableButtonsTypes],
+      },
+    },
   },
 }
 
@@ -180,6 +196,7 @@ export const Default = (args) => ({
       :size="size"
       :color-palette="colorPalette"
       :tooltip-position="tooltipPosition"
+      :type="type"
     />
   `,
 })
@@ -284,6 +301,7 @@ export const FullWidth = (args) => ({
       :size="size"
       :is-full-width="isFullWidth"
       :label="label"
+      :type="type"
     />
   </div>`,
 })
@@ -312,6 +330,7 @@ export const JustIcons = (args) => ({
       :icon="icon"
       :is-loading="isLoading"
       :is-disabled="isDisabled"
+      :type="type"
       has-icon-only
     />
 
@@ -321,6 +340,7 @@ export const JustIcons = (args) => ({
       :icon="icon"
       :is-loading="isLoading"
       :is-disabled="isDisabled"
+      :type="type"
       has-icon-only
     />
 
@@ -332,6 +352,7 @@ export const JustIcons = (args) => ({
       :is-disabled="isDisabled"
       :icon-description="iconDescription"
       is-rounded
+      :type="type"
       has-icon-only
       :tooltip-position="tooltipPosition"
     />
@@ -363,6 +384,7 @@ export const InlineLabel = (args) => ({
       :is-disabled="isDisabled"
       :size="size"
       :is-full-width="isFullWidth"
+      :type="type"
     >
       {{ label }}
     </SbButton>
@@ -392,6 +414,7 @@ export const LoadingButton = (args) => ({
       :is-disabled="isDisabled"
       :size="size"
       :color-palette="colorPalette"
+      :type="type"
     />`,
 })
 

--- a/src/components/Button/__tests__/Button.spec.js
+++ b/src/components/Button/__tests__/Button.spec.js
@@ -147,4 +147,37 @@ describe('Test SbButton Component', () => {
       expect(wrapper.find('.sb-tooltip').text()).toBe(iconDescription)
     })
   })
+
+  describe('when the user add a type for the button', () => {
+    const renderButton = (type) => {
+      return mount(SbButton, {
+        propsData: {
+          colorPalette: 'ghost',
+          type: type,
+        },
+      })
+    }
+
+    it('should be a button with a type `button`', () => {
+      const wrapper = renderButton('button')
+      expect(wrapper.attributes('type')).toBe('button')
+    })
+
+    it('should be a button with a type `submit`', () => {
+      const wrapper = renderButton('submit')
+      expect(wrapper.attributes('type')).toBe('submit')
+    })
+
+    it('should be a button with a type `reset`', () => {
+      const wrapper = renderButton('reset')
+      expect(wrapper.attributes('type')).toBe('reset')
+    })
+
+    it('should not render the prop `type` when sending an invalid value', () => {
+      const validator = SbButton.props.type.validator
+      expect(validator('info')).toBe(false)
+      expect(validator('warning')).toBe(false)
+      expect(validator('test')).toBe(false)
+    })
+  })
 })

--- a/src/components/Button/__tests__/Button.spec.js
+++ b/src/components/Button/__tests__/Button.spec.js
@@ -48,7 +48,7 @@ describe('Test SbButton Component', () => {
   it('test SbButton in secondary color', async () => {
     const wrapper = factory({
       label: 'Secondary Button',
-      type: 'secondary',
+      colorPalette: 'secondary',
     })
 
     expect(wrapper.find('button').attributes('class')).toBe(

--- a/src/components/Button/__tests__/Button.spec.js
+++ b/src/components/Button/__tests__/Button.spec.js
@@ -48,7 +48,7 @@ describe('Test SbButton Component', () => {
   it('test SbButton in secondary color', async () => {
     const wrapper = factory({
       label: 'Secondary Button',
-      colorPalette: 'secondary',
+      variant: 'secondary',
     })
 
     expect(wrapper.find('button').attributes('class')).toBe(
@@ -152,7 +152,7 @@ describe('Test SbButton Component', () => {
     const renderButton = (type) => {
       return mount(SbButton, {
         propsData: {
-          colorPalette: 'ghost',
+          variant: 'ghost',
           type: type,
         },
       })

--- a/src/components/Button/button.scss
+++ b/src/components/Button/button.scss
@@ -82,11 +82,11 @@
   }
 
   &--small {
-    padding: 0.8rem 1.6rem;
+    padding: 0.9rem;
   }
   
   &--large {
-    padding: 2rem 4.3rem;
+    padding: 2.1rem;
   }
 
   &[disabled] {

--- a/src/components/Button/button.scss
+++ b/src/components/Button/button.scss
@@ -82,11 +82,11 @@
   }
 
   &--small {
-    padding: 0.9rem;
+    padding: 0.8rem 1.6rem;
   }
   
   &--large {
-    padding: 2.1rem;
+    padding: 2rem 4.3rem;
   }
 
   &[disabled] {
@@ -128,6 +128,14 @@
     .sb-icon {
       margin: 0;
     }
+  }
+
+  &--has-icon-only#{&}--small {
+    padding: 0.9rem;
+  }
+
+  &--has-icon-only#{&}--large {
+    padding: 2.1rem;
   }
 
   &--loading {

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -100,7 +100,7 @@ const SbButton = {
       return h(
         'button',
         {
-          staticClass: `sb-button sb-button--${this.colorPalette}`,
+          staticClass: `sb-button sb-button--${this.variant}`,
           attrs: {
             ...this.$attrs,
             disabled: this.isDisabled,
@@ -137,9 +137,9 @@ const SbButton = {
             type: 'spinner',
             size: 'small',
             color:
-              this.colorPalette === 'primary' ||
-              this.colorPalette === 'secondary' ||
-              this.colorPalette === 'danger'
+              this.variant === 'primary' ||
+              this.variant === 'secondary' ||
+              this.variant === 'danger'
                 ? 'white'
                 : 'primary-dark',
           },

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -100,11 +100,12 @@ const SbButton = {
       return h(
         'button',
         {
-          staticClass: `sb-button sb-button--${this.type}`,
+          staticClass: `sb-button sb-button--${this.colorPalette}`,
           attrs: {
             ...this.$attrs,
             disabled: this.isDisabled,
             'aria-disabled': this.isDisabled,
+            type: this.type,
           },
           class: {
             'sb-button--disabled': this.isDisabled,
@@ -136,9 +137,9 @@ const SbButton = {
             type: 'spinner',
             size: 'small',
             color:
-              this.type === 'primary' ||
-              this.type === 'secondary' ||
-              this.type === 'danger'
+              this.colorPalette === 'primary' ||
+              this.colorPalette === 'secondary' ||
+              this.colorPalette === 'danger'
                 ? 'white'
                 : 'primary-dark',
           },

--- a/src/components/Button/lib.js
+++ b/src/components/Button/lib.js
@@ -3,16 +3,31 @@ import { includes, availableSizes } from '../../utils'
 /**
  * @type {Array<string>}
  */
-export const availableTypes = ['primary', 'secondary', 'ghost', 'danger']
+export const availableColorsPalette = [
+  'primary',
+  'secondary',
+  'ghost',
+  'danger',
+]
+
+/**
+ * @type {Array<string>}
+ */
+export const availableButtonsTypes = ['button', 'submit', 'reset']
 
 export const sharedProps = {
   size: {
     type: String,
     validator: (size) => includes(availableSizes, size),
   },
-  type: {
+  colorPalette: {
     type: String,
     default: 'primary',
-    validator: (type) => includes(availableTypes, type),
+    validator: (type) => includes(availableColorsPalette, type),
+  },
+  type: {
+    type: String,
+    default: null,
+    validator: (type) => includes(availableButtonsTypes, type),
   },
 }

--- a/src/components/Button/lib.js
+++ b/src/components/Button/lib.js
@@ -3,12 +3,7 @@ import { includes, availableSizes } from '../../utils'
 /**
  * @type {Array<string>}
  */
-export const availableColorsPalette = [
-  'primary',
-  'secondary',
-  'ghost',
-  'danger',
-]
+export const availableVariants = ['primary', 'secondary', 'ghost', 'danger']
 
 /**
  * @type {Array<string>}
@@ -20,10 +15,10 @@ export const sharedProps = {
     type: String,
     validator: (size) => includes(availableSizes, size),
   },
-  colorPalette: {
+  variant: {
     type: String,
     default: 'primary',
-    validator: (type) => includes(availableColorsPalette, type),
+    validator: (type) => includes(availableVariants, type),
   },
   type: {
     type: String,

--- a/src/components/EditorHeader/EditorHeader.vue
+++ b/src/components/EditorHeader/EditorHeader.vue
@@ -63,7 +63,7 @@
           <SbButton
             size="small"
             label="Publish"
-            type="primary"
+            color-palette="primary"
             @click="handlePublishSpace"
           />
         </SbHeaderItem>

--- a/src/components/EditorHeader/EditorHeader.vue
+++ b/src/components/EditorHeader/EditorHeader.vue
@@ -63,7 +63,7 @@
           <SbButton
             size="small"
             label="Publish"
-            color-palette="primary"
+            variant="primary"
             @click="handlePublishSpace"
           />
         </SbHeaderItem>

--- a/src/components/EditorHeader/components/HeaderTitle.vue
+++ b/src/components/EditorHeader/components/HeaderTitle.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="format !== 'desktop'" class="sb-editor--title">
-    <SbButton icon="plus" color-palette="secondary" size="small" />
+    <SbButton icon="plus" variant="secondary" size="small" />
     <span>{{ title }}</span>
   </div>
 </template>

--- a/src/components/EditorHeader/components/HeaderTitle.vue
+++ b/src/components/EditorHeader/components/HeaderTitle.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="format !== 'desktop'" class="sb-editor--title">
-    <SbButton icon="plus" type="secondary" size="small" />
+    <SbButton icon="plus" color-palette="secondary" size="small" />
     <span>{{ title }}</span>
   </div>
 </template>

--- a/src/components/GroupButton/GroupButton.stories.js
+++ b/src/components/GroupButton/GroupButton.stories.js
@@ -1,14 +1,14 @@
 import SbGroupButton from '.'
 import SbButton from '../Button/index'
 
-import { availableColorsPalette } from '../Button/lib'
+import { availableVariants } from '../Button/lib'
 import { availableSizes } from '../../utils'
 
 export default {
   title: 'SbGroupButton',
   component: SbGroupButton,
   args: {
-    colorPalette: 'ghost',
+    variant: 'ghost',
     size: null,
     hasSpaces: false,
   },
@@ -21,12 +21,12 @@ export default {
         options: [...availableSizes],
       },
     },
-    colorPalette: {
-      name: 'colorPalette',
-      description: '`SbButton` colorPalette',
+    variant: {
+      name: 'variant',
+      description: '`SbButton` variant',
       control: {
         type: 'select',
-        options: [...availableColorsPalette],
+        options: [...availableVariants],
       },
     },
     hasSpaces: {
@@ -43,7 +43,7 @@ export const Default = (args) => ({
   components: { SbGroupButton, SbButton },
   props: Object.keys(args),
   template: `
-    <SbGroupButton v-bind="{ size, colorPalette, hasSpaces }">
+    <SbGroupButton v-bind="{ size, variant, hasSpaces }">
       <SbButton label="First Button" />
       <SbButton label="Secondary Button" />
       <SbButton label="Third Button" />
@@ -55,7 +55,7 @@ export const WithIcons = (args) => ({
   components: { SbGroupButton, SbButton },
   props: Object.keys(args),
   template: `
-    <SbGroupButton v-bind="{ size, colorPalette, hasSpaces }">
+    <SbGroupButton v-bind="{ size, variant, hasSpaces }">
       <SbButton :label="firstLabel" />
       <SbButton :label="secondaryLabel" />
       <SbButton has-icon-only icon="close" />
@@ -85,7 +85,7 @@ export const JustIcons = (args) => ({
   components: { SbGroupButton, SbButton },
   props: Object.keys(args),
   template: `
-    <SbGroupButton v-bind="{ size, colorPalette, hasSpaces }">
+    <SbGroupButton v-bind="{ size, variant, hasSpaces }">
       <SbButton has-icon-only icon="calendar" iconDescription="Calendar Icon" />
       <SbButton has-icon-only icon="plus" iconDescription="Plus Icon" />
       <SbButton has-icon-only icon="overflow-menu-vertic" iconDescription="Overflow Icon" />

--- a/src/components/GroupButton/GroupButton.stories.js
+++ b/src/components/GroupButton/GroupButton.stories.js
@@ -1,14 +1,14 @@
 import SbGroupButton from '.'
 import SbButton from '../Button/index'
 
-import { availableTypes } from '../Button/lib'
+import { availableColorsPalette } from '../Button/lib'
 import { availableSizes } from '../../utils'
 
 export default {
   title: 'SbGroupButton',
   component: SbGroupButton,
   args: {
-    type: 'ghost',
+    colorPalette: 'ghost',
     size: null,
     hasSpaces: false,
   },
@@ -21,12 +21,12 @@ export default {
         options: [...availableSizes],
       },
     },
-    type: {
-      name: 'type',
-      description: '`SbButton` type',
+    colorPalette: {
+      name: 'colorPalette',
+      description: '`SbButton` colorPalette',
       control: {
         type: 'select',
-        options: [...availableTypes],
+        options: [...availableColorsPalette],
       },
     },
     hasSpaces: {
@@ -43,7 +43,7 @@ export const Default = (args) => ({
   components: { SbGroupButton, SbButton },
   props: Object.keys(args),
   template: `
-    <SbGroupButton v-bind="{ size, type, hasSpaces }">
+    <SbGroupButton v-bind="{ size, colorPalette, hasSpaces }">
       <SbButton label="First Button" />
       <SbButton label="Secondary Button" />
       <SbButton label="Third Button" />
@@ -55,7 +55,7 @@ export const WithIcons = (args) => ({
   components: { SbGroupButton, SbButton },
   props: Object.keys(args),
   template: `
-    <SbGroupButton v-bind="{ size, type, hasSpaces }">
+    <SbGroupButton v-bind="{ size, colorPalette, hasSpaces }">
       <SbButton :label="firstLabel" />
       <SbButton :label="secondaryLabel" />
       <SbButton has-icon-only icon="close" />
@@ -85,7 +85,7 @@ export const JustIcons = (args) => ({
   components: { SbGroupButton, SbButton },
   props: Object.keys(args),
   template: `
-    <SbGroupButton v-bind="{ size, type, hasSpaces }">
+    <SbGroupButton v-bind="{ size, colorPalette, hasSpaces }">
       <SbButton has-icon-only icon="calendar" iconDescription="Calendar Icon" />
       <SbButton has-icon-only icon="plus" iconDescription="Plus Icon" />
       <SbButton has-icon-only icon="overflow-menu-vertic" iconDescription="Overflow Icon" />

--- a/src/components/GroupButton/__tests__/GroupButton.spec.js
+++ b/src/components/GroupButton/__tests__/GroupButton.spec.js
@@ -48,9 +48,9 @@ describe('Tests SbGroupButton component', () => {
       })
     })
 
-    it('should have the correct type property in each child component', () => {
+    it('should have the correct colorPalette property in each child component', () => {
       const template = `
-        <SbGroupButton size="small" type="ghost">
+        <SbGroupButton size="small" colorPalette="ghost">
           <SbButton label="One" />
           <SbButton label="Two" />
           <SbButton label="Three" />
@@ -60,7 +60,7 @@ describe('Tests SbGroupButton component', () => {
 
       wrapper.findAllComponents(SbButton).wrappers.forEach((wrapper) => {
         expect(wrapper.props('size')).toBe('small')
-        expect(wrapper.props('type')).toBe('ghost')
+        expect(wrapper.props('colorPalette')).toBe('ghost')
       })
     })
   })

--- a/src/components/GroupButton/__tests__/GroupButton.spec.js
+++ b/src/components/GroupButton/__tests__/GroupButton.spec.js
@@ -48,9 +48,9 @@ describe('Tests SbGroupButton component', () => {
       })
     })
 
-    it('should have the correct colorPalette property in each child component', () => {
+    it('should have the correct variant property in each child component', () => {
       const template = `
-        <SbGroupButton size="small" colorPalette="ghost">
+        <SbGroupButton size="small" variant="ghost">
           <SbButton label="One" />
           <SbButton label="Two" />
           <SbButton label="Three" />
@@ -60,7 +60,7 @@ describe('Tests SbGroupButton component', () => {
 
       wrapper.findAllComponents(SbButton).wrappers.forEach((wrapper) => {
         expect(wrapper.props('size')).toBe('small')
-        expect(wrapper.props('colorPalette')).toBe('ghost')
+        expect(wrapper.props('variant')).toBe('ghost')
       })
     })
   })

--- a/src/components/Menu/Menu.stories.js
+++ b/src/components/Menu/Menu.stories.js
@@ -174,7 +174,7 @@ export const AlongWithGroup = (args) => ({
   template: `
     <div style="display: flex; justify-content: center;">
       <SbMenu :value="value">
-        <SbGroupButton colorPalette="ghost">
+        <SbGroupButton variant="ghost">
           <SbButton label="Define Schema" />
           <SbMenuButton has-icon-only />
         </SbGroupButton>

--- a/src/components/Menu/Menu.stories.js
+++ b/src/components/Menu/Menu.stories.js
@@ -174,7 +174,7 @@ export const AlongWithGroup = (args) => ({
   template: `
     <div style="display: flex; justify-content: center;">
       <SbMenu :value="value">
-        <SbGroupButton type="ghost">
+        <SbGroupButton colorPalette="ghost">
           <SbButton label="Define Schema" />
           <SbMenuButton has-icon-only />
         </SbGroupButton>

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -423,7 +423,7 @@ const SbMenuButton = {
           isRounded: this.isRounded,
           hasIconOnly: true,
           icon: this.iconName || 'overflow-menu-vertic',
-          type: this.type,
+          colorPalette: this.type,
         },
         on: {
           ...this.$listeners,
@@ -448,7 +448,7 @@ const SbMenuButton = {
         props: {
           iconRight: 'chevron-down',
           label: this.label,
-          type: this.type,
+          colorPalette: this.type,
         },
         on: {
           ...this.$listeners,

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -423,7 +423,7 @@ const SbMenuButton = {
           isRounded: this.isRounded,
           hasIconOnly: true,
           icon: this.iconName || 'overflow-menu-vertic',
-          colorPalette: this.type,
+          variant: this.type,
         },
         on: {
           ...this.$listeners,
@@ -448,7 +448,7 @@ const SbMenuButton = {
         props: {
           iconRight: 'chevron-down',
           label: this.label,
-          colorPalette: this.type,
+          variant: this.type,
         },
         on: {
           ...this.$listeners,

--- a/src/components/Modal/SbModal.stories.js
+++ b/src/components/Modal/SbModal.stories.js
@@ -29,7 +29,7 @@ const ModalTemplate = (args) => ({
     <div>
       <SbButton
         label="Open Modal!"
-        colorPalette="primary"
+        variant="primary"
         @click="handleShowModal"
         v-if="!showModal"
         style="margin: 0 auto; display: flex; margin-top: 30%;"
@@ -52,8 +52,8 @@ const ModalTemplate = (args) => ({
         </SbModalContent>
 
         <SbModalFooter>
-          <SbButton label="Label" colorPalette="primary"/>
-          <SbButton label="Label" colorPalette="ghost"/>
+          <SbButton label="Label" variant="primary"/>
+          <SbButton label="Label" variant="ghost"/>
         </SbModalFooter>
 
       </SbModal>
@@ -140,7 +140,7 @@ export const ModalWithoutFooter = (args) => ({
   <div>
     <SbButton
       label="Open Modal!"
-      colorPalette="primary"
+      variant="primary"
       @click="handleShowModal"
       v-if="!showModal"
       style="margin: 0 auto; display: flex; margin-top: 30%;"
@@ -156,7 +156,7 @@ export const ModalWithoutFooter = (args) => ({
         <p style="font-size: 16px; color: rgb(84, 91, 111); text-align: center;">The body copy that explains empty state</p>
       </SbModalContent>
 
-      <SbButton label="Click me!" colorPalette="primary"/>
+      <SbButton label="Click me!" variant="primary"/>
     </SbModal>
   </div>
   `,
@@ -190,7 +190,7 @@ export const ModalWithoutHeader = (args) => ({
   <div>
     <SbButton
       label="Open Modal!"
-      colorPalette="primary"
+      variant="primary"
       @click="handleShowModal"
       v-if="!showModal"
       style="margin: 0 auto; display: flex; margin-top: 30%;"
@@ -201,7 +201,7 @@ export const ModalWithoutHeader = (args) => ({
       </SbModalContent>
 
       <SbModalFooter>
-        <SbButton label="Click me!" colorPalette="primary"/>
+        <SbButton label="Click me!" variant="primary"/>
       </SbModalFooter>
     </SbModal>
   </div>`,
@@ -237,7 +237,7 @@ export const ModalWithMediumSize = (args) => ({
   <div>
     <SbButton
       label="Open Modal!"
-      colorPalette="primary"
+      variant="primary"
       @click="handleShowModal"
       v-if="!showModal"
       style="margin: 0 auto; display: flex; margin-top: 30%;"
@@ -250,8 +250,8 @@ export const ModalWithMediumSize = (args) => ({
       </SbModalContent>
 
       <SbModalFooter>
-        <SbButton label="Label" colorPalette="primary"/>
-        <SbButton label="Label" colorPalette="ghost"/>
+        <SbButton label="Label" variant="primary"/>
+        <SbButton label="Label" variant="ghost"/>
       </SbModalFooter>
     </SbModal>
   </div>`,
@@ -289,7 +289,7 @@ export const ModalTypeComponentConfirm = (args) => ({
     <div>
       <SbButton
         label="Open Modal!"
-        colorPalette="primary"
+        variant="primary"
         @click="handleShowModal"
         style="margin: 0 auto; display: flex; margin-top: 30%;"
       />
@@ -336,7 +336,7 @@ export const ModalTypeComponentDelete = (args) => ({
     <div>
       <SbButton
         label="Open Modal!"
-        colorPalette="primary"
+        variant="primary"
         @click="handleShowModal"
         style="margin: 0 auto; display: flex; margin-top: 30%;"
       />

--- a/src/components/Modal/SbModal.stories.js
+++ b/src/components/Modal/SbModal.stories.js
@@ -71,6 +71,9 @@ export default {
           'Modals focus the user’s attention exclusively on one task or piece of information via a window that sits on top of the page content.',
       },
     },
+    // Sets a delay for the component's stories
+    // the animation of the Modal is 0.5s or 500ms
+    chromatic: { delay: 600 },
   },
   args: {
     title: 'Main title',

--- a/src/components/Modal/SbModal.stories.js
+++ b/src/components/Modal/SbModal.stories.js
@@ -29,7 +29,7 @@ const ModalTemplate = (args) => ({
     <div>
       <SbButton
         label="Open Modal!"
-        type="primary"
+        colorPalette="primary"
         @click="handleShowModal"
         v-if="!showModal"
         style="margin: 0 auto; display: flex; margin-top: 30%;"
@@ -52,8 +52,8 @@ const ModalTemplate = (args) => ({
         </SbModalContent>
 
         <SbModalFooter>
-          <SbButton label="Label" type="primary"/>
-          <SbButton label="Label" type="ghost"/>
+          <SbButton label="Label" colorPalette="primary"/>
+          <SbButton label="Label" colorPalette="ghost"/>
         </SbModalFooter>
 
       </SbModal>
@@ -140,7 +140,7 @@ export const ModalWithoutFooter = (args) => ({
   <div>
     <SbButton
       label="Open Modal!"
-      type="primary"
+      colorPalette="primary"
       @click="handleShowModal"
       v-if="!showModal"
       style="margin: 0 auto; display: flex; margin-top: 30%;"
@@ -156,7 +156,7 @@ export const ModalWithoutFooter = (args) => ({
         <p style="font-size: 16px; color: rgb(84, 91, 111); text-align: center;">The body copy that explains empty state</p>
       </SbModalContent>
 
-      <SbButton label="Click me!" type="primary"/>
+      <SbButton label="Click me!" colorPalette="primary"/>
     </SbModal>
   </div>
   `,
@@ -190,7 +190,7 @@ export const ModalWithoutHeader = (args) => ({
   <div>
     <SbButton
       label="Open Modal!"
-      type="primary"
+      colorPalette="primary"
       @click="handleShowModal"
       v-if="!showModal"
       style="margin: 0 auto; display: flex; margin-top: 30%;"
@@ -201,7 +201,7 @@ export const ModalWithoutHeader = (args) => ({
       </SbModalContent>
 
       <SbModalFooter>
-        <SbButton label="Click me!" type="primary"/>
+        <SbButton label="Click me!" colorPalette="primary"/>
       </SbModalFooter>
     </SbModal>
   </div>`,
@@ -237,7 +237,7 @@ export const ModalWithMediumSize = (args) => ({
   <div>
     <SbButton
       label="Open Modal!"
-      type="primary"
+      colorPalette="primary"
       @click="handleShowModal"
       v-if="!showModal"
       style="margin: 0 auto; display: flex; margin-top: 30%;"
@@ -250,8 +250,8 @@ export const ModalWithMediumSize = (args) => ({
       </SbModalContent>
 
       <SbModalFooter>
-        <SbButton label="Label" type="primary"/>
-        <SbButton label="Label" type="ghost"/>
+        <SbButton label="Label" colorPalette="primary"/>
+        <SbButton label="Label" colorPalette="ghost"/>
       </SbModalFooter>
     </SbModal>
   </div>`,
@@ -289,7 +289,7 @@ export const ModalTypeComponentConfirm = (args) => ({
     <div>
       <SbButton
         label="Open Modal!"
-        type="primary"
+        colorPalette="primary"
         @click="handleShowModal"
         style="margin: 0 auto; display: flex; margin-top: 30%;"
       />
@@ -336,7 +336,7 @@ export const ModalTypeComponentDelete = (args) => ({
     <div>
       <SbButton
         label="Open Modal!"
-        type="primary"
+        colorPalette="primary"
         @click="handleShowModal"
         style="margin: 0 auto; display: flex; margin-top: 30%;"
       />

--- a/src/components/Modal/SbModal.stories.js
+++ b/src/components/Modal/SbModal.stories.js
@@ -23,7 +23,7 @@ const ModalTemplate = (args) => ({
     },
   },
   data: () => ({
-    showModal: false,
+    showModal: true,
   }),
   template: `
     <div>
@@ -48,7 +48,7 @@ const ModalTemplate = (args) => ({
         />
 
         <SbModalContent>
-          <p>The body copy that explains empty state</p>
+          <p style="text-align:center">The body copy that explains empty state</p>
         </SbModalContent>
 
         <SbModalFooter>
@@ -134,7 +134,7 @@ export const ModalWithoutFooter = (args) => ({
     },
   },
   data: () => ({
-    showModal: false,
+    showModal: true,
   }),
   template: `
   <div>
@@ -156,7 +156,7 @@ export const ModalWithoutFooter = (args) => ({
         <p style="font-size: 16px; color: rgb(84, 91, 111); text-align: center;">The body copy that explains empty state</p>
       </SbModalContent>
 
-      <SbButton label="Click me!" variant="primary"/>
+      <SbButton label="Click me!" variant="primary" style="margin: 0 auto;display: flex"/>
     </SbModal>
   </div>
   `,
@@ -184,7 +184,7 @@ export const ModalWithoutHeader = (args) => ({
     },
   },
   data: () => ({
-    showModal: false,
+    showModal: true,
   }),
   template: `
   <div>
@@ -231,7 +231,7 @@ export const ModalWithMediumSize = (args) => ({
     },
   },
   data: () => ({
-    showModal: false,
+    showModal: true,
   }),
   template: `
   <div>
@@ -280,6 +280,9 @@ ModalInFullWidth.args = {
 export const ModalTypeComponentConfirm = (args) => ({
   props: Object.keys(args),
   components: { SbModalType },
+  mounted() {
+    this.handleShowModal()
+  },
   methods: {
     handleShowModal() {
       this.$refs.modal.show()
@@ -327,6 +330,9 @@ ModalTypeComponentConfirm.parameters = {
 export const ModalTypeComponentDelete = (args) => ({
   props: Object.keys(args),
   components: { SbModalType },
+  mounted() {
+    this.handleShowModal()
+  },
   methods: {
     handleShowModal() {
       this.$refs.modal.show()

--- a/src/components/Modal/SbModalType.vue
+++ b/src/components/Modal/SbModalType.vue
@@ -8,12 +8,12 @@
 
       <div>
         <SbButton
-          color-palette="ghost"
+          variant="ghost"
           :label="cancelButtonLabel"
           @click="handleCancelAction"
         />
         <SbButton
-          :color-palette="isConfirmationType"
+          :variant="isConfirmationType"
           :label="actionButtonLabel"
           @click="handleDispatchAction"
         />

--- a/src/components/Modal/SbModalType.vue
+++ b/src/components/Modal/SbModalType.vue
@@ -6,7 +6,7 @@
         {{ message }}
       </SbModalContent>
 
-      <div>
+      <div class="sb-modal__type--buttons">
         <SbButton
           variant="ghost"
           :label="cancelButtonLabel"

--- a/src/components/Modal/SbModalType.vue
+++ b/src/components/Modal/SbModalType.vue
@@ -8,12 +8,12 @@
 
       <div>
         <SbButton
-          type="ghost"
+          color-palette="ghost"
           :label="cancelButtonLabel"
           @click="handleCancelAction"
         />
         <SbButton
-          :type="isConfirmationType"
+          :color-palette="isConfirmationType"
           :label="actionButtonLabel"
           @click="handleDispatchAction"
         />

--- a/src/components/Modal/__tests__/Modal.spec.js
+++ b/src/components/Modal/__tests__/Modal.spec.js
@@ -35,11 +35,11 @@ describe('Tests for SbModal', () => {
         <SbModalFooter>
             <SbButton
               label="Save"
-              type="primary"
+              colorPalette="primary"
             />
             <SbButton
               label="Cancel"
-              type="primary"
+              colorPalette="primary"
             />
         </SbModalFooter>
       </SbModal>

--- a/src/components/Modal/__tests__/Modal.spec.js
+++ b/src/components/Modal/__tests__/Modal.spec.js
@@ -35,11 +35,11 @@ describe('Tests for SbModal', () => {
         <SbModalFooter>
             <SbButton
               label="Save"
-              colorPalette="primary"
+              variant="primary"
             />
             <SbButton
               label="Cancel"
-              colorPalette="primary"
+              variant="primary"
             />
         </SbModalFooter>
       </SbModal>

--- a/src/components/Modal/modal.scss
+++ b/src/components/Modal/modal.scss
@@ -39,6 +39,7 @@
     min-height: 3rem;
     font-size: $font-size-default;
     color: $sb-dark-blue-75;
+    text-align: center;
   }
 
   &-footer {
@@ -100,5 +101,10 @@
   &__full-width {
     max-width: 100%;
     min-width: 62rem;
+  }
+
+  &__type--buttons {
+    display: flex;
+    justify-content: center;
   }
 }

--- a/src/components/Slideover/Slideover.stories.js
+++ b/src/components/Slideover/Slideover.stories.js
@@ -38,8 +38,8 @@ const SlideoverTemplate = (args) => ({
         </SbModalContent>
 
         <SbModalFooter>
-          <SbButton label="Label" colorPalette="primary"/>
-          <SbButton label="Label" colorPalette="ghost"/>
+          <SbButton label="Label" variant="primary"/>
+          <SbButton label="Label" variant="ghost"/>
         </SbModalFooter>
       </SbSlideover>
     </div>

--- a/src/components/Slideover/Slideover.stories.js
+++ b/src/components/Slideover/Slideover.stories.js
@@ -28,12 +28,12 @@ const SlideoverTemplate = (args) => ({
         label="Open Slideover!"
         @click="handleOpenSlide"
         style="margin: 0 auto; display: flex; margin-top: 30%;"/>
-      
+
       <SbSlideover
         :is-open="show"
         @hide="show = false"
         :orientation="orientation">
-        
+
         <SbModalHeader title="Title" align="left" />
 
         <SbModalContent style="flex: 1;">
@@ -58,6 +58,9 @@ export default {
         component:
           'Slideover focus the user’s attention exclusively on one task or piece of information via a window that sits on top of the page content.',
       },
+      // Sets a delay for the component's stories
+      // the animation of the Slideover is 0.2s or 200ms
+      chromatic: { delay: 300 },
     },
     args: {
       orientation: 'right',
@@ -149,8 +152,8 @@ export const SlideoverInMaxSize = (args) => ({
         <SbModalHeader title="Hi man" align="left" />
 
         <SbModalContent style="flex: 1;">
-          <p>Storyblok helps your team to tell your story and manage 
-          content for every use-case: corporate websites, e-commerce, 
+          <p>Storyblok helps your team to tell your story and manage
+          content for every use-case: corporate websites, e-commerce,
           helpdesks, mobile apps, and screen displays.</p>
         </SbModalContent>
       </SbSlideover>

--- a/src/components/Slideover/Slideover.stories.js
+++ b/src/components/Slideover/Slideover.stories.js
@@ -38,8 +38,8 @@ const SlideoverTemplate = (args) => ({
         </SbModalContent>
 
         <SbModalFooter>
-          <SbButton label="Label" type="primary"/>
-          <SbButton label="Label" type="ghost"/>
+          <SbButton label="Label" colorPalette="primary"/>
+          <SbButton label="Label" colorPalette="ghost"/>
         </SbModalFooter>
       </SbSlideover>
     </div>

--- a/src/components/Slideover/Slideover.stories.js
+++ b/src/components/Slideover/Slideover.stories.js
@@ -11,6 +11,9 @@ const SlideoverTemplate = (args) => ({
     SbModalFooter,
   },
   props: Object.keys(args),
+  mounted() {
+    this.handleOpenSlide()
+  },
   methods: {
     handleOpenSlide() {
       this.show = true
@@ -84,6 +87,9 @@ SlideoverOnLeft.args = {
 export const SlideoverWithoutFooter = (args) => ({
   components: { SbSlideover, SbButton, SbModalHeader, SbModalContent },
   props: Object.keys(args),
+  mounted() {
+    this.handleOpenSlide()
+  },
   methods: {
     handleOpenSlide() {
       this.show = true
@@ -117,6 +123,9 @@ export const SlideoverWithoutFooter = (args) => ({
 export const SlideoverInMaxSize = (args) => ({
   components: { SbSlideover, SbButton, SbModalHeader, SbModalContent },
   props: Object.keys(args),
+  mounted() {
+    this.handleOpenSlide()
+  },
   methods: {
     handleOpenSlide() {
       this.show = true

--- a/src/components/Slideover/__tests__/Slideover.spec.js
+++ b/src/components/Slideover/__tests__/Slideover.spec.js
@@ -25,8 +25,8 @@ describe('SbSlideover component', () => {
         </SbModalContent>
 
         <SbModalFooter>
-          <SbButton label="Label" colorPalette="primary"/>
-          <SbButton label="Label" colorPalette="ghost"/>
+          <SbButton label="Label" variant="primary"/>
+          <SbButton label="Label" variant="ghost"/>
         </SbModalFooter>
       </SbSlideover>
     `,

--- a/src/components/Slideover/__tests__/Slideover.spec.js
+++ b/src/components/Slideover/__tests__/Slideover.spec.js
@@ -25,8 +25,8 @@ describe('SbSlideover component', () => {
         </SbModalContent>
 
         <SbModalFooter>
-          <SbButton label="Label" type="primary"/>
-          <SbButton label="Label" type="ghost"/>
+          <SbButton label="Label" colorPalette="primary"/>
+          <SbButton label="Label" colorPalette="ghost"/>
         </SbModalFooter>
       </SbSlideover>
     `,

--- a/src/components/TextField/textfield.scss
+++ b/src/components/TextField/textfield.scss
@@ -50,7 +50,7 @@
     }
 
     &--default {
-      border: solid 0.1rem $light;
+      border: 0.1rem solid $light;
 
       &:hover {
         border: 0.1rem solid $sb-green;
@@ -71,13 +71,11 @@
     }
 
     &--with-prefix {
-      border-left: none;
       border-top-left-radius: 0rem!important;
       border-bottom-left-radius: 0rem!important;
     }
 
     &--with-suffix {
-      border-right: none;
       border-top-right-radius: 0rem!important;
       border-bottom-right-radius: 0rem!important;
     }
@@ -114,11 +112,13 @@
   }
 
   &__prefix {
+    border-left: none;
     border-top-left-radius: 0rem;
     border-bottom-left-radius: 0rem;
   }
 
   &__suffix {
+    border-right: none;
     border-top-right-radius: 0rem;
     border-bottom-right-radius: 0rem;
   }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,5 @@
 import SbAvatar from './Avatar'
-import SbAbatarGroup from './AvatarGroup'
+import SbAvatarGroup from './AvatarGroup'
 import SbBadge from './Badge'
 import SbBlockUi from './BlockUI'
 import SbButton from './Button'
@@ -44,7 +44,7 @@ export { SbPopover, SbPopoverArrow } from './Popover'
 
 export {
   SbAvatar,
-  SbAbatarGroup,
+  SbAvatarGroup,
   SbBadge,
   SbBlockUi,
   SbButton,


### PR DESCRIPTION
In this PR was added to change the prop `type` name to `variant` and adding a prop `type` to be able to modify the `type` of the buttons.
- Adding the new logic to open **SbSLideover** and **SbModal** so when the story is opened.
- Modifying sb-textfield edges in the `:hover` effect.