### PR TITLE
Fix Modal overlay in Storybook docs

### DIFF
--- a/src/components/Modal/SbModal.vue
+++ b/src/components/Modal/SbModal.vue
@@ -59,8 +59,12 @@ export default {
   },
 
   watch: {
-    isOpen() {
-      this.open = this.isOpen
+    isOpen(value) {
+      if (value) {
+        this.handleOpenModal()
+      } else {
+        this.handleCloseModal()
+      }
     },
   },
 
@@ -72,9 +76,25 @@ export default {
     /**
      * handler for close modal
      */
-    handleCloseModal(event) {
-      this.open = false
-      this.$emit('hide')
+    handleCloseModal() {
+      if (this.open) {
+        this.open = false
+        this.$nextTick(() => {
+          this.$emit('hide')
+        })
+      }
+    },
+
+    /**
+     * handler for open modal
+     */
+    handleOpenModal() {
+      if (!this.open) {
+        this.open = true
+        this.$nextTick(() => {
+          this.$emit('show')
+        })
+      }
     },
 
     wrapClose(event) {

--- a/src/components/Slideover/Slideover.vue
+++ b/src/components/Slideover/Slideover.vue
@@ -53,8 +53,12 @@ export default {
     },
   },
   watch: {
-    isOpen() {
-      this.openBlokUI = this.isOpen
+    isOpen(state) {
+      if (state) {
+        this.handleOpenSlide()
+      } else {
+        this.handleCloseSlide()
+      }
     },
   },
   methods: {
@@ -62,8 +66,24 @@ export default {
      * handler for close the component
      */
     handleCloseSlide() {
-      this.openBlokUI = false
-      this.$emit('hide')
+      if (this.openBlokUI) {
+        this.openBlokUI = false
+        this.$nextTick(() => {
+          this.$emit('hide')
+        })
+      }
+    },
+
+    /**
+     * handler for open the component
+     */
+    handleOpenSlide() {
+      if (!this.openBlokUI) {
+        this.openBlokUI = true
+        this.$nextTick(() => {
+          this.$emit('show')
+        })
+      }
     },
   },
 }


### PR DESCRIPTION
This PR implements a fix to Modal overlay bug in docs pages. When it access this page, all the modals are opened at once, causing a strange behavior. This code is a downgrade to the logic to open the modal in the story by default, because we do not have how to know in which context the story is executed in the confident way.

We tried:
* To upgrade the version to latest (`v6.1.11`), but, the stories is mounting twice.
* To try to use the `location.search` to get the viewMode parameter in iframe URL (workaround in `v6.0`), but, when it move the context, the viewMode does not change properly.