### PR TITLE
INT-4: changing the test script so that the tests run with the node LTS 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,16 +15,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-      # Using the LTS versions
-        node-version: "lts/*"
-
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: lts/*
     - run: yarn
     - run: yarn test:unit --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: lts/*
     - run: yarn


### PR DESCRIPTION
I'm opening this PR to fix the bug in the test script, because in the [last PR](https://github.com/storyblok/storyblok-design-system/pull/65) we continued with the list structure but we added the lts version as a string and so the script didn't work.
Now I'm removing the whole version list structure from node and entering just one string, as directed by João.

Any questions I'm available!