### PR TITLE
INT-21 - Feature - Refactor on imports

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2021 Storyblok
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -27,16 +27,6 @@ yarn test:unit
 yarn lint
 ```
 
-## Usage
-To learn how to use the Storyblok's Design System in your project go to:
-[https://www.storyblok.com/docs/guide/in-depth/design-system](https://www.storyblok.com/docs/guide/in-depth/design-system)
-
-## Thanks
-
-<a href="https://www.chromatic.com/"><img src="https://user-images.githubusercontent.com/321738/84662277-e3db4f80-af1b-11ea-88f5-91d67a5e59f6.png" width="153" height="30" alt="Chromatic" /></a>
-
-Thanks to [Chromatic](https://www.chromatic.com/) for providing the visual testing platform that helps us review UI changes and catch visual regressions.
-
 ---
 
 <p align="center">

--- a/config/globals.js
+++ b/config/globals.js
@@ -1,10 +1,12 @@
-const path = require('path')
+// const path = require('path')
 
 const globalStyles = [
-  path.resolve(__dirname, '../src/assets/styles/variables.scss'),
-  path.resolve(__dirname, '../src/assets/styles/mixins.scss')
+  // path.resolve(__dirname, '../src/assets/styles/globals.scss'),
+  // path.resolve(__dirname, '../src/assets/styles/resets.scss'),
+  // path.resolve(__dirname, '../src/assets/styles/variables.scss'),
+  // path.resolve(__dirname, '../src/assets/styles/mixins.scss'),
 ]
 
 module.exports = {
-  globalStyles
+  globalStyles,
 }

--- a/config/globals.js
+++ b/config/globals.js
@@ -1,10 +1,10 @@
-// const path = require('path')
+const path = require('path')
 
 const globalStyles = [
-  // path.resolve(__dirname, '../src/assets/styles/globals.scss'),
-  // path.resolve(__dirname, '../src/assets/styles/resets.scss'),
-  // path.resolve(__dirname, '../src/assets/styles/variables.scss'),
-  // path.resolve(__dirname, '../src/assets/styles/mixins.scss'),
+  path.resolve(__dirname, '../src/assets/styles/globals.scss'),
+  path.resolve(__dirname, '../src/assets/styles/resets.scss'),
+  path.resolve(__dirname, '../src/assets/styles/variables.scss'),
+  path.resolve(__dirname, '../src/assets/styles/mixins.scss'),
 ]
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "storyblok-design-system",
   "version": "0.0.0-development",
+  "license": "MIT",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --target lib ./src/main.js",

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -1,4 +1,3 @@
-// @import './resets';
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700&display=swap');
 
 html {

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -1,4 +1,4 @@
-@import './resets';
+// @import './resets';
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700&display=swap');
 
 html {

--- a/src/components/Button/__tests__/Button.spec.js
+++ b/src/components/Button/__tests__/Button.spec.js
@@ -157,6 +157,7 @@ describe('Test SbButton Component', () => {
 
     it('should have a tooltip with correct text', async () => {
       await wrapper.find('button').trigger('focus')
+      // expect(wrapper.find('.sb-tooltip').text()).toBe(iconDescription)
       expect(document.querySelector('[role="tooltip"]').innerText).toBe(
         iconDescription
       )

--- a/src/components/Menu/__tests__/Menu.spec.js
+++ b/src/components/Menu/__tests__/Menu.spec.js
@@ -25,6 +25,7 @@ describe('SbMenu component', () => {
           <SbMenuList
             placement="bottom-start"
             data-testid="menu-list"
+            :custom-class="'menu-list-options'"
           >
             <SbMenuGroup title="Actions">
               <SbMenuItem> Option 1 </SbMenuItem>
@@ -227,5 +228,11 @@ describe('SbMenu component', () => {
 
     // and the focus should be move to the button
     expect(buttonComponent.element).toEqual(document.activeElement)
+  })
+
+  it('should exist the custom class', async () => {
+    const menuListComponent = wrapper.find('[role="menu"]')
+
+    expect(menuListComponent.classes('menu-list-options')).toBe(true)
   })
 })

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -231,6 +231,10 @@ const SbMenuList = {
       type: Number,
       default: 5,
     },
+    customClass: {
+      type: String,
+      default: '',
+    },
   },
 
   computed: {
@@ -358,6 +362,7 @@ const SbMenuList = {
               role: 'menu',
               'aria-labelledby': menuButtonId,
             },
+            class: this.customClass,
             on: {
               keydown: this.handleKeyDown,
             },

--- a/src/components/Modal/SbModal.vue
+++ b/src/components/Modal/SbModal.vue
@@ -7,7 +7,7 @@
     target-slim
     :target="modalTarget"
   >
-    <SbBlokUi v-if="open" @mousedown="wrapClose">
+    <SbBlokUi v-if="open" :style="computedBlokUiStyle" @mousedown="wrapClose">
       <div
         ref="modal"
         class="sb-modal"
@@ -16,7 +16,7 @@
         :style="computedStyle"
         v-bind="{ ...$attrs }"
       >
-        <SbModalCloseButton />
+        <SbModalCloseButton v-if="showClose" />
         <slot />
       </div>
     </SbBlokUi>
@@ -66,9 +66,21 @@ export default {
       type: String,
       default: () => `#sb-modal-target-${randomString(4)}`,
     },
+    overlayPosition: {
+      type: String,
+      default: 'fixed',
+    },
+    overlayTransparent: {
+      type: Boolean,
+      default: false,
+    },
     customClass: {
       type: String,
       default: '',
+    },
+    showClose: {
+      type: Boolean,
+      default: true,
     },
   },
 
@@ -87,6 +99,14 @@ export default {
         this.scrollbar && 'sb-modal--scrollbar',
         this.closeOnHeader && 'sb-modal--close-on-header',
       ]
+    },
+
+    computedBlokUiStyle() {
+      const style = { position: this.overlayPosition }
+
+      if (this.overlayTransparent) style.background = 'none'
+
+      return { ...style }
     },
 
     computedStyle() {

--- a/src/components/Popover/index.js
+++ b/src/components/Popover/index.js
@@ -5,8 +5,10 @@ import {
   offset,
   preventOverflow,
   arrow,
+  hide,
 } from '@popperjs/core/lib/modifiers'
 
+import './popover.scss'
 import SbPortal from '../Portal'
 
 import { randomString, canUseDOM, includes } from '../../utils'
@@ -108,6 +110,7 @@ const SbPopover = {
           },
         },
         arrow,
+        hide,
       ]
 
       return [...defaultModifierValues, ...this.modifiers]
@@ -262,6 +265,7 @@ const SbPopover = {
           {
             attrs: {
               id: this.anchorId,
+              class: 'sb-popover',
               ...this.$attrs,
             },
             style: {

--- a/src/components/Popover/popover.scss
+++ b/src/components/Popover/popover.scss
@@ -1,5 +1,7 @@
-.menu {
-  @include popoverComponent();
-  width: 100%;
-  max-width: 184px;
+.sb-popover[data-popper-reference-hidden] {
+  opacity: 0;
+  pointer-events: none;
+  position: fixed !important;
+  right: 200%;
+  visibility: hidden;
 }

--- a/src/components/Portal/index.js
+++ b/src/components/Portal/index.js
@@ -97,7 +97,7 @@ const SbPortal = {
      * remove from the DOM the portal target
      */
     unmountTarget() {
-      if (!this.disabled && this.unmountOnDestroy) {
+      if (!this.disabled && this.unmountOnDestroy && !this.target.length) {
         canUseDOM &&
           this.portalTarget.isConnected &&
           document.body.removeChild(this.portalTarget)

--- a/src/components/Sidebar/sidebar.scss
+++ b/src/components/Sidebar/sidebar.scss
@@ -34,8 +34,9 @@
     box-sizing: border-box;
     display: inline-flex;
     flex-direction: column;
+    max-width: 280px;
     min-height: 100vh;
-    transition: all 0.2s ease;
+    transition: max-width 0.2s ease;
     width: 280px;
 
     &:hover .sb-button {
@@ -133,7 +134,7 @@
   // modifiers
   &--minimize {
     .sb-sidebar__content {
-      width: 80px;
+      max-width: 80px;
     }
 
     .sb-icon,
@@ -143,6 +144,11 @@
 
     .sb-sidebar-link--use-avatar {
       padding: 9px 15px 9px 17px;
+
+      .sb-avatar {
+        left: -8px;
+        position: relative;
+      }
     }
 
     .sb-sidebar-toggle .sb-button {
@@ -174,8 +180,6 @@
   }
 
   &--minimize &-link {
-    justify-content: center;
-
     &__label {
       display: none;
     }

--- a/src/components/Slideover/Slideover.stories.js
+++ b/src/components/Slideover/Slideover.stories.js
@@ -62,18 +62,18 @@ export default {
       // the animation of the Slideover is 0.2s or 200ms
       chromatic: { delay: 300 },
     },
-    args: {
-      orientation: 'right',
-    },
-    argTypes: {
-      orientation: {
-        name: 'orientation',
-        description:
-          'The prop `orientation` is used to define the position where the `Slideover` component will appear, the options are on the `left` or `right`, the default is on the `right`.',
-        control: {
-          type: 'select',
-          options: ['left', 'right'],
-        },
+  },
+  args: {
+    orientation: 'right',
+  },
+  argTypes: {
+    orientation: {
+      name: 'orientation',
+      description:
+        'The prop `orientation` is used to define the position where the `Slideover` component will appear, the options are on the `left` or `right`, the default is on the `right`.',
+      control: {
+        type: 'select',
+        options: ['left', 'right'],
       },
     },
   },

--- a/src/components/Slideover/Slideover.stories.js
+++ b/src/components/Slideover/Slideover.stories.js
@@ -62,18 +62,18 @@ export default {
       // the animation of the Slideover is 0.2s or 200ms
       chromatic: { delay: 300 },
     },
-  },
-  args: {
-    orientation: 'right',
-  },
-  argTypes: {
-    orientation: {
-      name: 'orientation',
-      description:
-        'The prop `orientation` is used to define the position where the `Slideover` component will appear, the options are on the `left` or `right`, the default is on the `right`.',
-      control: {
-        type: 'select',
-        options: ['left', 'right'],
+    args: {
+      orientation: 'right',
+    },
+    argTypes: {
+      orientation: {
+        name: 'orientation',
+        description:
+          'The prop `orientation` is used to define the position where the `Slideover` component will appear, the options are on the `left` or `right`, the default is on the `right`.',
+        control: {
+          type: 'select',
+          options: ['left', 'right'],
+        },
       },
     },
   },

--- a/src/directives/tooltip/__tests__/VTooltip.spec.js
+++ b/src/directives/tooltip/__tests__/VTooltip.spec.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 
+// import { mountAttachingComponent } from '../../../utils/tests-utils'
 import Tooltip from '..'
 
 const mountWithTemplate = (template) => {

--- a/src/lib/internal-icons.js
+++ b/src/lib/internal-icons.js
@@ -586,6 +586,14 @@ const icons = {
     path: `
     <path fill="currentColor" fill-rule="evenodd" d="M7.558 5a2 2 0 0 1 1.898 1.368l.088.264A2 2 0 0 0 11.442 8H18a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h1.558zM12 10.5c-.84 0-1.5.732-1.5 1.611V13H10a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1h-.5v-.889l-.006-.145c-.068-.813-.7-1.466-1.494-1.466zm0 1c.264 0 .5.263.5.611V13h-1v-.889l.007-.102c.04-.296.256-.509.493-.509z"/>`,
   },
+  'content-story': {
+    viewBox: '0 0 24 24',
+    path: `<path d="M13 5a2 2 0 0 1 1.995 1.85L15 7v10a2 2 0 0 1-1.85 1.995L13 19H6a2 2 0 0 1-1.995-1.85L4 17V7a2 2 0 0 1 1.85-1.995L6 5h7Zm5 2a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2h-1V7h1Zm-5 0H6v10h7V7Z" fill="currentColor" fill-rule="evenodd"/>`,
+  },
+  'content-story-fill': {
+    viewBox: '0 0 24 24',
+    path: `<path d="M13 5a2 2 0 0 1 1.995 1.85L15 7v10a2 2 0 0 1-1.85 1.995L13 19H6a2 2 0 0 1-1.995-1.85L4 17V7a2 2 0 0 1 1.85-1.995L6 5h7Zm5 2a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2h-1V7h1Z" fill="currentColor" fill-rule="evenodd"/>`,
+  },
 }
 
 const partnerIcons = {

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 // Import global assets
-import './assets/styles/global.scss'
+// import './assets/styles/global.scss'
 
 // Import vue components
 import * as components from './components'

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 // Import global assets
-// import './assets/styles/global.scss'
+import './assets/styles/global.scss'
 
 // Import vue components
 import * as components from './components'


### PR DESCRIPTION
This PR is about this task [INT-21](https://storyblok.atlassian.net/browse/INT-21).

**One can test this by following these steps:**
1. Create a brand new nuxt or vue app
2. Install the DS from this branch with this command `yarn add git+https://github.com/storyblok/storyblok-design-system#feature/INT-21`
3. Clone this branch to your machine
4. Run yarn build
5. Copy the files from `dist` folder
6. Paste these files inside the `dist` folder from `node_modules` > `storyblok-design-system` > `dist`
7. These steps are required, because the yarn install from branch doesn't generate these files. This won't happen by installing from npm/yarn official source.
8. Follow the instructions from [here](https://www.storyblok.com/docs/guide/in-depth/design-system) to add the DS on the new app.
9. Add some Components to the app
10. All components should behave as expected

The manual imports as described on Nuxt session inside documentation, are no more necessary. So the Documentation must be updated.
Further tests could be done after this merge is done to beta branch, so we can test its functions from the true source.
This PR also adds a license field to package.json and a license file as well.

