### PR TITLE
`INT-21` - Feature/int 21

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2021 Storyblok
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/config/globals.js
+++ b/config/globals.js
@@ -1,10 +1,12 @@
 const path = require('path')
 
 const globalStyles = [
+  path.resolve(__dirname, '../src/assets/styles/globals.scss'),
+  path.resolve(__dirname, '../src/assets/styles/resets.scss'),
   path.resolve(__dirname, '../src/assets/styles/variables.scss'),
-  path.resolve(__dirname, '../src/assets/styles/mixins.scss')
+  path.resolve(__dirname, '../src/assets/styles/mixins.scss'),
 ]
 
 module.exports = {
-  globalStyles
+  globalStyles,
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "storyblok-design-system",
   "version": "0.0.0-development",
+  "license": "MIT",
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --target lib ./src/main.js",

--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -1,4 +1,3 @@
-@import './resets';
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700&display=swap');
 
 html {

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -225,8 +225,10 @@ const SbMenuList = {
       default: 'bottom-end',
     },
     // eslint-disable-next-line
-    reference: [String, Element, Object],
-    usePortal: Boolean,
+    reference: [String, Object, Element],
+    usePortal: {
+      type: Boolean,
+    },
     zIndex: {
       type: Number,
       default: 5,

--- a/src/components/Popover/index.js
+++ b/src/components/Popover/index.js
@@ -66,7 +66,9 @@ const SbPopover = {
     },
 
     // component itself properties
-    isOpen: Boolean,
+    isOpen: {
+      type: Boolean,
+    },
     offset: {
       type: Array,
       default: () => [0, 8],
@@ -78,9 +80,13 @@ const SbPopover = {
     // eslint-disable-next-line
     reference: [String, Element],
     // eslint-disable-next-line
-    useAnchorId: String,
+    useAnchorId: {
+      type: String,
+    },
     // eslint-disable-next-line
-    usePortalTarget: String,
+    usePortalTarget: {
+      type: String,
+    },
     usePortal: {
       type: Boolean,
       default: false,

--- a/src/components/Slideover/Slideover.vue
+++ b/src/components/Slideover/Slideover.vue
@@ -33,7 +33,9 @@ export default {
     SbBlokUi,
   },
   props: {
-    isOpen: Boolean,
+    isOpen: {
+      type: Boolean,
+    },
     orientation: {
       type: String,
       default: 'right',


### PR DESCRIPTION
This PR is about this task [INT-21](https://storyblok.atlassian.net/browse/INT-21).

**One can test this by following these steps:**
1. Create a brand new nuxt or vue app
2. Install the DS from this branch with this command `yarn add git+https://github.com/storyblok/storyblok-design-system#feature/INT-21`
3. Clone this branch to your machine
4. Run yarn build
5. Copy the files from `dist` folder
6. Paste these files inside the `dist` folder from `node_modules` > `storyblok-design-system` > `dist`
7. These steps are required, because the yarn install from branch doesn't generate these files. This won't happen by installing from npm/yarn official source.
8. Follow the instructions from [here](https://www.storyblok.com/docs/guide/in-depth/design-system) to add the DS on the new app.

9. For Nuxt, if you created a SSR app, follow these steps:
10. Create a `plugins` directory inside your nuxt app
11. Create a file with name `storyblok-design-system.js` inside it
12. Paste this code:
`import Vue from 'vue'
import BlokInk from 'storyblok-design-system'
import 'storyblok-design-system/dist/storyblok-design-system.css'
Vue.use(BlokInk)`
13.  On `nuxt.config.js` add these lines:
`plugins: [{src: '@/plugins/storyblok-design-system', mode: 'client'}],`
14. Add some Components to the app
15. All components should behave as expected

The manual imports as described on Nuxt session inside documentation, are no more necessary. Also the plugins process would be necessary from now on. So the Documentation must be updated.
Further tests could be done after this merge is done to beta branch, so we can test its functions from the true source.
This PR also adds a license field to package.json and a license file as well.