### PR TITLE
`INT-41` - modal fix on storybook docs

### DIFF
--- a/src/components/UploadDialog/UploadDialog.stories.js
+++ b/src/components/UploadDialog/UploadDialog.stories.js
@@ -51,6 +51,12 @@ export default {
       },
     },
   },
+
+  parameters: {
+    docs: {
+      inlineStories: false,
+    },
+  },
 }
 
 export const Default = (args) => ({

--- a/src/components/UploadDialog/UploadDialog.vue
+++ b/src/components/UploadDialog/UploadDialog.vue
@@ -35,15 +35,15 @@ export default {
       default: null,
     },
     percentageValue: {
-      type: Number,
+      type: [Number, String],
       default: 0,
     },
     timeLeft: {
-      type: Number,
+      type: [Number, String],
       default: 0,
     },
     totalFiles: {
-      type: Number,
+      type: [Number, String],
       default: 0,
     },
   },
@@ -57,10 +57,9 @@ export default {
     },
 
     uploadingLabel() {
-      if (this.totalFiles === 1) {
-        return `Uploading ${this.currentFile} of ${this.totalFiles} file`
-      }
-      return `Uploading ${this.currentFile} of ${this.totalFiles} files`
+      const label = `Uploading ${this.currentFile} of ${this.totalFiles}`
+
+      return this.totalFiles > 1 ? `${label} files` : `${label} file`
     },
 
     timeLeftLabel() {


### PR DESCRIPTION
This PR is related to this [issue](https://storyblok.atlassian.net/browse/INT-41) and fixes the modal issue on `SbUploadDialog` component, when visualizing it from storybook's docs, like this [link](https://blok.ink/?path=/docs/design-system-components-sbuploaddialog--default).

Note that you cannot interact with the elements that are behind the modal. 

How to test:

- Clone this repository
- Switch to this branch `fix/INT-41-modal-fix-on-storybook-docs`.
- Run `yarn install`
- Run `yarn storybook`
- Go to [localhost](http://localhost:6006/?path=/docs/design-system-components-sbuploaddialog--default) and see the changes