### PR TITLE
INT-210[bugfix]: Add condition in the Sidebar ListItem to show the icon when needed

### DIFF
--- a/src/components/Sidebar/components/ListItem.vue
+++ b/src/components/Sidebar/components/ListItem.vue
@@ -111,7 +111,7 @@ export default {
     },
 
     hasIcon() {
-      return this.icon !== null
+      return this.icon
     },
   },
 }

--- a/src/components/Sidebar/components/ListItem.vue
+++ b/src/components/Sidebar/components/ListItem.vue
@@ -21,7 +21,7 @@
     >
       <SbAvatar v-if="hasAvatar" v-bind="avatar" />
 
-      <SbIcon v-else :size="iconSize" :name="icon" />
+      <SbIcon v-else-if="hasIcon" :size="iconSize" :name="icon" />
 
       <span class="sb-sidebar-link__label">
         {{ label }}
@@ -108,6 +108,10 @@ export default {
 
     hasIconBefore() {
       return this.iconBefore !== null
+    },
+
+    hasIcon() {
+      return this.icon !== null
     },
   },
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
This PR is needed to fix the storyfront console error described in the parent task:
Error: <svg> attribute viewBox: Unexpected end of attribute.

This was happening because the ListItem, which is the Sidebar submenu, was expecting an icon and in some cases we need the submenu without an icon.

To correct I added a condition to display the SbIcon whenever the component receives information in the icon attribute.

## Pull request type

Jira Link: [INT-210 - Add condition in the Sidebar ListItem to show the icon when needed](https://storyblok.atlassian.net/browse/INT-210)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please describe how others can test this PR -->

In Menu > Components > Sibebar > Open a doc and open browser console:

In props > listItems remove the icon from one of the objects.
Note that the error described at the beginning of this PR will not be displayed.

## Other information
Any problem I'm available!
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
