### PR TITLE
 INT-104[bugfix]: fix avatar and icon fallback empty nodes

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -204,7 +204,7 @@ const SbAvatar = {
     }
 
     const renderAvatar = () => {
-      if (this.$slots.default || this.isImageLoaded) {
+      if (this.$slots.default || this.isImageLoaded || !this.name) {
         return h(
           'div',
           {

--- a/src/components/Icon/Icon.stories.js
+++ b/src/components/Icon/Icon.stories.js
@@ -62,7 +62,7 @@ Default.args = {
 
 export const FallbackIcon = () => ({
   components: { SbIcon },
-  template: '<SbIcon name="fallback" size="x-large" />',
+  template: '<SbIcon name="avatar-fallback" size="x-large" color="green" />',
 })
 
 export const IconSizes = () => ({


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
This PR is needed to fix the empty nodes on two components SbIcon and SbAvatar.

## Pull request type

Jira Link: [INT-104 - Design System - Empty nodes on blok.ink](https://storyblok.atlassian.net/browse/INT-104)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please describe how others can test this PR -->

In Menu > Components > SbAvatar > With Fallback
Check that the icons is displayed.

In Menu > Components > SbIcon > Fallback Icon
Check that the icon is displayed.

## Other information
Any problem I'm available!
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
