### PR TITLE
INT-24[feature]: Disable SbButton when displaying the load 

### DIFF
--- a/src/components/Button/button.scss
+++ b/src/components/Button/button.scss
@@ -151,12 +151,16 @@
   }
 
   &[disabled] {
-    color: $light-gray;
-    background-color: $light;
     cursor: not-allowed;
 
-    .sb-icon {
-      opacity: 0.5;
+    &:not(.sb-button--loading) {
+      color: $light-gray;
+      background-color: $light;
+
+
+      .sb-icon {
+        opacity: 0.5;
+      }
     }
   }
 

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -114,8 +114,8 @@ const SbButton = {
           staticClass: `sb-button sb-button--${this.variant}`,
           attrs: {
             ...this.$attrs,
-            disabled: this.isDisabled,
-            'aria-disabled': this.isDisabled,
+            disabled: this.isDisabled || this.isLoading,
+            'aria-disabled': this.isDisabled || this.isLoading,
             type: this.type,
           },
           class: {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
In this PR we disable "SbButton" while "IsLoading" is active. So the user can't trigger another request before everything is loaded.

## Pull request type

Jira Link: [INT-24 - Disable SbButton when displaying the load.](https://storyblok.atlassian.net/browse/INT-24)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please describe how others can test this PR -->

In Menu > Components > SbButton  > Loading button
Check if it's disabled.



## Other information
Any problem I'm available!
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
