### PR TITLE
INT-189[bugfix]: Change margin bottom the sb-modal-footer in sbSlideOver 

### DIFF
--- a/src/components/Slideover/slideover.scss
+++ b/src/components/Slideover/slideover.scss
@@ -37,4 +37,8 @@
     cursor: pointer;
     appearance: none;
   }
+
+  .sb-modal-footer {
+    margin-bottom: -20px;
+  }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
This PR is needed to fix the bottom padding of the SbSlideOver component, as the footer was not padding.

## Pull request type

Jira Link: [INT-189 -  SbSlideOver: Bottom padding is missing](https://storyblok.atlassian.net/browse/INT-189)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please describe how others can test this PR -->

In Menu > Components > SbSlideOver 
Make sure the footer has space between the text and the component's border.

## Other information
Any problem I'm available!
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
