### PR TITLE
[WIP]bugfix(INT-12): SbNumberForm remove double storke

### DIFF
--- a/src/components/NumberField/numberfield.scss
+++ b/src/components/NumberField/numberfield.scss
@@ -124,6 +124,7 @@
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
   appearance: none;
+  appearance: none;
 }
 
 @supports (-webkit-appearance:none) and (stroke-color:transparent) {

--- a/src/components/NumberField/numberfield.scss
+++ b/src/components/NumberField/numberfield.scss
@@ -124,7 +124,6 @@
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
   appearance: none;
-  appearance: none;
 }
 
 @supports (-webkit-appearance:none) and (stroke-color:transparent) {

--- a/src/components/NumberField/numberfield.scss
+++ b/src/components/NumberField/numberfield.scss
@@ -123,7 +123,7 @@
 
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
-  appearance: none;
+  -webkit-appearance: none;
 }
 
 @supports (-webkit-appearance:none) and (stroke-color:transparent) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
This PR is needed to fix the border in SbNumberField in Safari.

## Pull request type

Jira Link: [INT-12](https://storyblok.atlassian.net/browse/INT-12)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please describe how others can test this PR -->

In Menu > Components > Form > SbNumberField  > Default
Check that the borders its ok in Safari



## Other information
Any problem I'm available!
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
