### PR TITLE
Add logo prop to sidebar

### DIFF
--- a/src/components/Sidebar/Sidebar.stories.js
+++ b/src/components/Sidebar/Sidebar.stories.js
@@ -120,6 +120,7 @@ export default {
   args: {
     listItems: [...listItemsData],
     minimize: false,
+    logo: '',
   },
   argTypes: {
     minimize: {
@@ -128,6 +129,13 @@ export default {
         'Minimize the Sidebar to just show the icons. When use this property, you should put the `sync` modifier (like `:minimize.sync`) to allow the sidebar change the state itself',
       control: {
         type: 'boolean',
+      },
+    },
+    logo: {
+      name: 'logo',
+      description: 'Adds a custom logo (with a url to an image) to the sidebar',
+      control: {
+        type: 'string',
       },
     },
   },

--- a/src/components/Sidebar/Sidebar.stories.js
+++ b/src/components/Sidebar/Sidebar.stories.js
@@ -63,7 +63,7 @@ const SidebarTemplate = (args) => ({
   template: `
     <SbSidebar
       v-bind="{ listItems }"
-
+      :logo="logo"
       :minimize.sync="internalMinimize"
     >
 
@@ -148,4 +148,10 @@ Minimized.parameters = {
         'When you define the sidebar as `minimize`, it will collapse the sidebar to just show the link icons.',
     },
   },
+}
+
+export const CustomLogo = SidebarTemplate.bind({})
+
+CustomLogo.args = {
+  logo: 'https://bcassetcdn.com/social/bvrg7kkg12/preview.png',
 }

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -14,7 +14,8 @@
       </div>
 
       <div class="sb-sidebar__mobile-logo">
-        <SbSidebarLogo variant="dark" />
+        <img v-if="logo" class="sb-custom-logo" :src="logo" />
+        <SbSidebarLogo v-else variant="dark" />
       </div>
 
       <div v-if="isMobileOpen" class="sb-sidebar__mobile-header-close-icon">
@@ -26,7 +27,8 @@
 
     <div class="sb-sidebar__content">
       <div class="sb-sidebar__top">
-        <SbSidebarLogo :minimize="minimize" />
+        <img v-if="logo" class="sb-custom-logo" :src="logo" />
+        <SbSidebarLogo v-else :minimize="minimize" />
       </div>
 
       <SbSidebarList>
@@ -76,6 +78,10 @@ export default {
     minimize: {
       type: Boolean,
       default: false,
+    },
+    logo: {
+      type: String,
+      default: '',
     },
   },
 

--- a/src/components/Sidebar/sidebar.scss
+++ b/src/components/Sidebar/sidebar.scss
@@ -54,6 +54,10 @@
       margin-left: 30px;
       cursor: pointer;
     }
+
+    .sb-custom-logo {
+      width: 100%;
+    }
   }
 
   &-logo {


### PR DESCRIPTION
Had to add a prop to add a custom logo if the customer wants to. The default value for the logo is the Storyblok logo as we have now.

![Captura de Tela 2022-02-15 às 18 38 12](https://user-images.githubusercontent.com/26799272/154153617-bcd30e57-0945-439b-ba43-bc2cd5479d7d.png)

This will be used by us when an organization sets its own logo, for example.