### PR TITLE
ON-298 - Scrollbar UX problem

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -70,3 +70,35 @@ button {
     font-size: $pair !important;
   }
 }
+
+// scrollbar
+
+// for firefox
+.transparent-scroll {
+  scrollbar-color: #c1c1c1 transparent;
+
+  &:hover {
+    scrollbar-color: #7d7d7d transparent;
+  }
+}
+
+// for other browsers
+.transparent-scroll::-webkit-scrollbar {
+  width: 15px;
+}
+
+.transparent-scroll::-webkit-scrollbar-thumb {
+  background-clip: padding-box;
+  background-color: #c1c1c1;
+  border-radius: 6px;
+  border-left: 3px solid transparent;
+  border-right: 3px solid transparent;
+
+  &:hover {
+    background-color: #7d7d7d;
+  }
+}
+
+.transparent-scroll::-webkit-scrollbar-track {
+  background-color: transparent;
+}

--- a/src/components/Sidebar/Sidebar.stories.js
+++ b/src/components/Sidebar/Sidebar.stories.js
@@ -23,7 +23,7 @@ export const listItemsData = [
   {
     href: '#',
     icon: 'partner-team',
-    iconBefore: 'chevron-down',
+    iconRight: 'chevron-down',
     label: 'Apps',
   },
 ]

--- a/src/components/Sidebar/components/ListItem.vue
+++ b/src/components/Sidebar/components/ListItem.vue
@@ -23,6 +23,8 @@
 
       <SbIcon v-else-if="hasIcon" :size="iconSize" :name="icon" />
 
+      <div v-if="hasSeparator" class="separator"></div>
+
       <span class="sb-sidebar-link__label">
         {{ label }}
       </span>
@@ -94,6 +96,10 @@ export default {
     to: {
       type: [String, Object],
       default: null,
+    },
+    hasSeparator: {
+      type: Boolean,
+      default: false,
     },
   },
 

--- a/src/components/Sidebar/components/ListItem.vue
+++ b/src/components/Sidebar/components/ListItem.vue
@@ -28,10 +28,10 @@
       </span>
 
       <SbIcon
-        v-if="hasIconBefore"
-        :size="iconBeforeSize"
-        :name="iconBefore"
-        class="sb-icon__before"
+        v-if="hasIconRight"
+        :size="iconRightSize"
+        :name="iconRight"
+        class="sb-icon__right"
       />
     </component>
 
@@ -83,11 +83,11 @@ export default {
       type: String,
       default: 'normal',
     },
-    iconBefore: {
+    iconRight: {
       type: String,
       default: null,
     },
-    iconBeforeSize: {
+    iconRightSize: {
       type: String,
       default: 'normal',
     },
@@ -106,8 +106,8 @@ export default {
       return this.avatar !== null
     },
 
-    hasIconBefore() {
-      return this.iconBefore !== null
+    hasIconRight() {
+      return this.iconRight
     },
 
     hasIcon() {

--- a/src/components/Sidebar/components/lists.js
+++ b/src/components/Sidebar/components/lists.js
@@ -16,7 +16,7 @@ const SbSidebarList = {
     return h(
       'ul',
       {
-        staticClass: 'sb-sidebar-list',
+        staticClass: 'sb-sidebar-list transparent-scroll',
         attrs: {
           role: 'navigation',
         },

--- a/src/components/Sidebar/sidebar.scss
+++ b/src/components/Sidebar/sidebar.scss
@@ -124,10 +124,17 @@
     .sb-icon {
       margin-right: 12px;
 
-      &__before {
+      &__right {
         position: absolute;
         right: 0;
       }
+    }
+
+    .sb-sidebar-link__label {
+      overflow: hidden;
+      min-height: 15px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .sb-avatar {

--- a/src/components/Sidebar/sidebar.scss
+++ b/src/components/Sidebar/sidebar.scss
@@ -34,6 +34,7 @@
     flex-direction: column;
     box-sizing: border-box;
     width: 280px;
+    max-height: 100vh;
     max-width: 280px;
     min-height: 100vh;
     background-color: $color-primary-dark;
@@ -83,6 +84,7 @@
     flex: 1;
     flex-direction: column;
     overflow-x: hidden;
+    overflow-y: auto;
     margin: 0;
     padding: 0;
   }

--- a/src/components/Sidebar/sidebar.scss
+++ b/src/components/Sidebar/sidebar.scss
@@ -130,6 +130,13 @@
       }
     }
 
+    .separator {
+      width: 1px;
+      height: 24px;
+      margin: 0 7px 0 -8px;
+      background-color: $light-gray;
+    }
+
     .sb-sidebar-link__label {
       overflow: hidden;
       min-height: 15px;


### PR DESCRIPTION
This PR adds a class `transparent-scroll` to the sidebar which styles the scrollbar on different browsers and also fixes the issue of having a double scrollbar when the sidebar is higher than 100vh.

Here's an example:

https://user-images.githubusercontent.com/26799272/154514968-0a5909a2-07d4-4d1c-8e6c-82d60af82c29.mov

Besides that, I did a refactor on the prop `iconBefore` that was wrong because it was about the icon on the right not on left.


