### PR TITLE
bugfix: colors of the avatars

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -1,7 +1,12 @@
 import './avatar.scss'
 
 import { canUseDOM, includes } from '../../utils'
-import { isSizeValid, getInitials, generateRandomColor } from './utils.js'
+import {
+  isSizeValid,
+  getInitials,
+  generateRandomBgColor,
+  generateRandomColor,
+} from './utils.js'
 
 import SbBadge from '../Badge'
 import SbIcon from '../Icon'
@@ -218,13 +223,14 @@ const SbAvatar = {
       }
 
       if (this.name || this.friendlyName) {
+        const color = this.bgColor || generateRandomBgColor()
+        const bgColorClass = this.bgColor ? 'bg-' + color : color
         return h(
           'div',
           {
-            staticClass: 'sb-avatar__initials',
+            staticClass: `sb-avatar__initials ${bgColorClass}`,
             attrs: {
               ...(this.useTooltip && { tabindex: 0 }),
-              style: 'background-color: ' + this.backgroundColor,
             },
           },
           [

--- a/src/components/Avatar/utils.js
+++ b/src/components/Avatar/utils.js
@@ -1,8 +1,7 @@
 import {
   getRandomNumber,
   availableSizes,
-  availableColors,
-  availableBgColors,
+  availableColorsNoWhite,
 } from '../../utils'
 
 /**
@@ -19,9 +18,9 @@ export const isSizeValid = (size) => availableSizes.indexOf(size) !== -1
  * @return {string}
  */
 export const generateRandomBgColor = () => {
-  const randomNumber = getRandomNumber(0, availableBgColors.length)
+  const randomNumber = getRandomNumber(0, availableColorsNoWhite.length)
 
-  return availableBgColors[randomNumber]
+  return 'bg-' + availableColorsNoWhite[randomNumber]
 }
 
 /**
@@ -30,9 +29,9 @@ export const generateRandomBgColor = () => {
  * @return {string}
  */
 export const generateRandomColor = () => {
-  const randomNumber = getRandomNumber(0, availableBgColors.length)
+  const randomNumber = getRandomNumber(0, availableColorsNoWhite.length)
 
-  return availableColors[randomNumber]
+  return availableColorsNoWhite[randomNumber]
 }
 
 /**

--- a/src/lib/internal-icons.js
+++ b/src/lib/internal-icons.js
@@ -69,7 +69,7 @@ const icons = {
     viewBox: '0 0 24 24',
     path: `
       <g fill="none" fill-rule="evenodd">
-        <circle cx="12" cy="12" r="11" fill="currentColor" stroke="#FFF" stroke-width="2"/>
+        <circle cx="12" cy="12" r="11" fill="currentColor"/>
         <path fill="#FFF" d="M10.53 14.47c.537.536 1.024.78 1.47.78.446 0 .933-.244 1.47-.78a.75.75 0 0 1 1.06 1.06c-.796.797-1.642 1.22-2.53 1.22-.888 0-1.734-.423-2.53-1.22a.75.75 0 0 1 1.06-1.06zM9 9a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm6 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
         <circle cx="17.5" cy="13.5" r="2.5" fill="#1B243F" opacity=".091"/>
         <circle cx="6.5" cy="13.5" r="2.5" fill="#1B243F" opacity=".091"/>

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -25,7 +25,9 @@ export const availableColors = [
 /**
  * @type {Array<string>}
  */
-export const availableBgColors = availableColors.map((color) => `bg-${color}`)
+export const availableColorsNoWhite = availableColors.filter(
+  (color) => color !== 'white'
+)
 
 /**
  * @type {Array<string>}


### PR DESCRIPTION
Nikola asked to adapt the avatars:

* The initials avatars will now use the DS colors:
![grafik](https://user-images.githubusercontent.com/11278408/154667509-fa4c3963-ac91-4bab-ae0c-e2b63f77557a.png)

* The avatars background will not use the white background anymore:
<img width="362" alt="grafik" src="https://user-images.githubusercontent.com/11278408/154667621-f004fe98-6569-4fb7-9d03-b8539347ebbb.png">

* The white border around the fallback is removed, so it's the same size as the initial avatar:

<img width="67" alt="grafik" src="https://user-images.githubusercontent.com/11278408/154667722-25651381-6394-46b8-8eaf-855fbe5d5abe.png">

