### PR TITLE
fix: checks if element is still on page to hide tooltip

### DIFF
--- a/src/directives/tooltip/index.js
+++ b/src/directives/tooltip/index.js
@@ -205,7 +205,7 @@ export default {
           el.__tooltip.options
         )
 
-        checkdelay = setInterval(function() {
+        checkdelay = setInterval(function () {
           if (!el.offsetHeight && el.__tooltip.popperInstance) {
             el.__tooltip.popperInstance.destroy()
             el.__tooltip.popperInstance = null

--- a/src/directives/tooltip/index.js
+++ b/src/directives/tooltip/index.js
@@ -179,6 +179,7 @@ export default {
 
     const options = getOptions(binding)
     const label = getLabel(binding)
+    let checkdelay
 
     function showHandler(e) {
       if (
@@ -203,6 +204,19 @@ export default {
           tooltip,
           el.__tooltip.options
         )
+
+        checkdelay = setInterval(function() {
+          if (!el.offsetHeight) {
+            if (el.__tooltip.popperInstance) {
+              el.__tooltip.popperInstance.destroy()
+              el.__tooltip.popperInstance = null
+            }
+          }
+
+          if (!el.__tooltip.popperInstance) {
+            clearInterval(checkdelay)
+          }
+        }, 150)
       }
     }
 

--- a/src/directives/tooltip/index.js
+++ b/src/directives/tooltip/index.js
@@ -206,11 +206,9 @@ export default {
         )
 
         checkdelay = setInterval(function() {
-          if (!el.offsetHeight) {
-            if (el.__tooltip.popperInstance) {
-              el.__tooltip.popperInstance.destroy()
-              el.__tooltip.popperInstance = null
-            }
+          if (!el.offsetHeight && el.__tooltip.popperInstance) {
+            el.__tooltip.popperInstance.destroy()
+            el.__tooltip.popperInstance = null
           }
 
           if (!el.__tooltip.popperInstance) {


### PR DESCRIPTION
Related to a bug STS-10 where the tooltip stays forever on a page. 