### PR TITLE
fix: removes tooltip dom element

### DIFF
--- a/src/directives/tooltip/index.js
+++ b/src/directives/tooltip/index.js
@@ -206,11 +206,7 @@ export default {
         )
 
         checkdelay = setInterval(function () {
-          if (
-            !el.offsetHeight &&
-            el.__tooltip.popperInstance &&
-            tooltip
-          ) {
+          if (!el.offsetHeight && el.__tooltip.popperInstance && tooltip) {
             cleanup(el)
           }
 

--- a/src/directives/tooltip/index.js
+++ b/src/directives/tooltip/index.js
@@ -211,9 +211,7 @@ export default {
             el.__tooltip.popperInstance &&
             tooltip
           ) {
-            el.__tooltip.popperInstance.destroy()
-            el.__tooltip.popperInstance = null
-            tooltip.remove()
+            cleanup(el)
           }
 
           if (!el.__tooltip.popperInstance) {

--- a/src/directives/tooltip/index.js
+++ b/src/directives/tooltip/index.js
@@ -206,9 +206,14 @@ export default {
         )
 
         checkdelay = setInterval(function () {
-          if (!el.offsetHeight && el.__tooltip.popperInstance) {
+          if (
+            !el.offsetHeight &&
+            el.__tooltip.popperInstance &&
+            tooltip
+          ) {
             el.__tooltip.popperInstance.destroy()
             el.__tooltip.popperInstance = null
+            tooltip.remove()
           }
 
           if (!el.__tooltip.popperInstance) {


### PR DESCRIPTION
There was still a bug that let the dom element stay on the page. This PR also removes also the dom element and not only the popper instance.