### PR TITLE
fix(datepicker): year background

### DIFF
--- a/src/components/Datepicker/datepicker.scss
+++ b/src/components/Datepicker/datepicker.scss
@@ -189,6 +189,7 @@
   flex-wrap: wrap;
   box-sizing: border-box;
   width: 100%;
+  background: $white;
 
   &__item {
     @include flexCentering();

--- a/src/components/Datepicker/datepicker.scss
+++ b/src/components/Datepicker/datepicker.scss
@@ -208,6 +208,7 @@
   box-sizing: border-box;
   width: 100%;
   max-height: 252px;
+  background: $white;
 
   &__item {
     @include flexCentering();


### PR DESCRIPTION
This should fix the following bug, when selecting a year or month in the datepicker. It adds a white background on the list.

<img width="200" alt="grafik" src="https://user-images.githubusercontent.com/11278408/155738127-eb981ec8-eac8-44ad-830c-320fd552686f.png">
<img width="200" alt="grafik" src="https://user-images.githubusercontent.com/11278408/155738561-7703e68f-c951-4b5e-94fe-be062349571e.png">


<img width="200" alt="grafik" src="https://user-images.githubusercontent.com/11278408/155738456-6b434911-dc22-4ca0-a22c-2b142fae2df8.png">
<img width="200" alt="grafik" src="https://user-images.githubusercontent.com/11278408/155738611-3c893c8e-5a18-4535-a0de-4fd3c1441c4d.png">


