### PR TITLE
Fix/Sidebar item

### DIFF
--- a/src/components/Sidebar/sidebar.scss
+++ b/src/components/Sidebar/sidebar.scss
@@ -130,6 +130,10 @@
   svg {
     min-width: 24px;
   }
+
+  .sb-icon__right {
+    pointer-events: none;
+  }
 }
 
 .sb-sidebar-item--parent {


### PR DESCRIPTION
After adding the clickoutside directive on the sidebar, the icon right of the sidebar was buggy:

https://user-images.githubusercontent.com/26799272/155768293-56abd248-2ec7-40cc-8f0b-a307d54f1a67.mov

This PR fixed this:

https://user-images.githubusercontent.com/26799272/155768317-a8bbade5-6ac6-411d-926f-ce2831eab212.mov
