### PR TITLE
fix(menu): add tab navigation

### DIFF
--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -287,6 +287,7 @@ const SbMenuList = {
           focusOnLastItem()
           break
         case 'Tab':
+          focusAtIndex((activeIndex + 1) % count)
           event.preventDefault()
           break
         case 'Escape':


### PR DESCRIPTION
This allows to navigate submenu by clicking the tab key (additional to arrow up and down).

https://user-images.githubusercontent.com/11278408/156160281-907c0135-8a50-4074-b0a5-b39da175751d.mov

 