### PR TITLE
hotfix(tooltip): tooltips should work on svg icons

### DIFF
--- a/src/directives/tooltip/index.js
+++ b/src/directives/tooltip/index.js
@@ -211,7 +211,12 @@ export default {
 
     function addInterval(tooltip, interval = 300) {
       return setInterval(() => {
-        if (!el.clientHeight && el.__tooltip.popperInstance && tooltip) {
+        const isVisible = !!(
+          el.offsetWidth ||
+          el.offsetHeight ||
+          el.getClientRects().length
+        )
+        if (!isVisible && el.__tooltip.popperInstance && tooltip) {
           cleanup(el)
         }
 

--- a/src/directives/tooltip/index.js
+++ b/src/directives/tooltip/index.js
@@ -205,16 +205,20 @@ export default {
           el.__tooltip.options
         )
 
-        checkdelay = setInterval(function () {
-          if (!el.offsetHeight && el.__tooltip.popperInstance && tooltip) {
-            cleanup(el)
-          }
-
-          if (!el.__tooltip.popperInstance) {
-            clearInterval(checkdelay)
-          }
-        }, 150)
+        checkdelay = addInterval(tooltip)
       }
+    }
+
+    function addInterval(tooltip, interval = 300) {
+      return setInterval(() => {
+        if (!el.clientHeight && el.__tooltip.popperInstance && tooltip) {
+          cleanup(el)
+        }
+
+        if (!el.__tooltip.popperInstance) {
+          clearInterval(checkdelay)
+        }
+      }, interval)
     }
 
     function hideHandler() {


### PR DESCRIPTION
This fixes the problem of the tooltips not working on SVG icons. SVG element do not have offsetHeight which causes flickering and the intervall to be triggered. Instead we use clientHeight to check if the cleanup should be triggered.

Related to https://storyblok.atlassian.net/browse/STS-10


Video of bug:

https://user-images.githubusercontent.com/11278408/156342578-a9667be1-9538-4ce8-ac7a-35e88a177998.mov


