### PR TITLE
fix: add conditional rendering

### DIFF
--- a/src/components/Sidebar/components/ListItem.vue
+++ b/src/components/Sidebar/components/ListItem.vue
@@ -24,7 +24,12 @@
         {{ label }}
       </span>
 
-      <SbIcon :size="iconRightSize" :name="iconRight" class="sb-icon__right" />
+      <SbIcon
+        v-if="iconRight"
+        :size="iconRightSize"
+        :name="iconRight"
+        class="sb-icon__right"
+      />
     </component>
 
     <slot />


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type


- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

This fix these console errors:

![Schermata 2022-03-09 alle 10 23 10](https://user-images.githubusercontent.com/4409084/157412691-03dbc811-7188-46c6-bfde-c5faf9afb71c.png)

As SbIcon always expects an icon as props to work, when this data is passed via a variable that can be or not there it breaks. Alternatively, it should be added a conditional rendering in the SbIcon template: src/components/Icon/index.js to prevent future errors for missing conditional rendering.