### PR TITLE
Feat/int 282 datepicker

### DIFF
--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -31,6 +31,7 @@ export default {
     value: '2021-12-02 00:00',
     type: 'datetime',
     disabled: false,
+    isoDate: false,
     timeZone: 'America/Detroit',
     tzTooltip: null,
   },
@@ -39,6 +40,11 @@ export default {
       name: 'timeZone',
       description:
         'Use this property to bind the user timezone, for example "America/Detroit". The component will calculate the offset automatically',
+      defaultValue: 'UTC',
+      table: {
+        type: { summary: 'String' },
+        defaultValue: { summary: 'UTC' },
+      },
       control: {
         type: 'text',
       },
@@ -46,9 +52,12 @@ export default {
     tzOffset: {
       name: 'tzOffset',
       description: `Use this property to bind the user tz offset. NOTE: If you use this, timeZone value will be disconsidered.
-        Examples:
-        GMT +05:00 or +05:00
-        GMT -03:00 or -03:00`,
+        Examples: GMT +05:00 or +05:00 GMT -03:00 or -03:00`,
+      defaultValue: '',
+      table: {
+        type: { summary: 'String' },
+        defaultValue: { summary: '' },
+      },
       control: {
         type: 'text',
       },
@@ -57,6 +66,11 @@ export default {
       name: 'tzTooltip',
       description:
         'Use this property to display a tooltip message for `timeZone` or `tzOffset` information.',
+      defaultValue: null,
+      table: {
+        type: { summary: 'String' },
+        defaultValue: { summary: 'null' },
+      },
       control: {
         type: 'text',
       },
@@ -65,8 +79,26 @@ export default {
       name: 'type',
       options: [...datepickerOptions],
       description: 'Change the type of the input.',
+      defaultValue: 'datetime',
+      table: {
+        type: { summary: 'String' },
+        defaultValue: { summary: 'datetime' },
+      },
       control: {
         type: 'select',
+      },
+    },
+    isoDate: {
+      name: 'isoDate',
+      description:
+        'If set to true, Datepicker will deliver the date as iso date format like 2010-02-27T05:00:37.845Z',
+      defaultValue: false,
+      table: {
+        type: { summary: 'Boolean' },
+        defaultValue: { summary: 'False' },
+      },
+      control: {
+        type: 'boolean',
       },
     },
   },

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -123,6 +123,11 @@ export default {
   props: {
     disabled: Boolean,
 
+    isoDate: {
+      type: Boolean,
+      default: false,
+    },
+
     placeholder: {
       type: String,
       default: null,
@@ -282,7 +287,12 @@ export default {
 
       this.hitClear = false
 
-      this.$emit('input', utcTime)
+      if (this.isoDate) {
+        this.isoString = dayjs.utc(utcTime).toISOString()
+        this.$emit('input', this.isoString)
+      } else {
+        this.$emit('input', utcTime)
+      }
 
       this.$nextTick(() => {
         this.closeOverlay()

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -161,7 +161,6 @@ export default {
   },
 
   data: () => ({
-    isoString: '',
     internalDate: dayjs().format(),
     internalValue: '',
     inputElement: null,
@@ -376,18 +375,6 @@ export default {
       }
 
       if (this.internalValue === 'Invalid Date') this.internalValue = ''
-
-      this.isoString = this.internalValue
-        ? dayjs.utc(value).utcOffset(this.tzOffset).toISOString()
-        : ''
-      console.log(
-        'isoString =>',
-        this.isoString,
-        'value =>',
-        value,
-        'internalValue =>',
-        this.internalValue
-      )
     },
 
     $_wrapClose(e) {

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -156,6 +156,7 @@ export default {
   },
 
   data: () => ({
+    isoString: '',
     internalDate: dayjs().format(),
     internalValue: '',
     inputElement: null,
@@ -365,6 +366,18 @@ export default {
       }
 
       if (this.internalValue === 'Invalid Date') this.internalValue = ''
+
+      this.isoString = this.internalValue
+        ? dayjs.utc(value).utcOffset(this.tzOffset).toISOString()
+        : ''
+      console.log(
+        'isoString =>',
+        this.isoString,
+        'value =>',
+        value,
+        'internalValue =>',
+        this.internalValue
+      )
     },
 
     $_wrapClose(e) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
This pull request adds a flag to deliver the date as Iso Date. If set to true, the date would be set in content object as Iso date. 

## Pull request type

Jira Link: [INT-282](https://storyblok.atlassian.net/browse/INT-282)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
Just use the Datepicker and set the prop flag iso-date as true. After saving the story, the content object must record the Datepicker data as Iso Date. If set to false, the value should be recorded normaly.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- A new flag was added to set the date as Iso Date. No further configuration or breaking changes are expected in order to this feature works properly.

## Other information
