### PR TITLE
story(WORK-57): stories action

### DIFF
--- a/src/components/DataTable/DataTable.stories.js
+++ b/src/components/DataTable/DataTable.stories.js
@@ -16,6 +16,8 @@ const description = {
   isLoading: 'Show a loading over the table.',
   items:
     'It must be an array. Each entry in the array represents a row in the table.',
+  keepSelectedOnChange:
+    'Saves the selected rows in memory in case there is a change of items, and selects the items again when reloading the same list.',
   selectionMode:
     'By default the selection mode is single, meaning only one row at a time can be selected. Use multiple, so multiple rows can be selected. `allowSelection: true` is required.',
   striped: 'Add zebra-striping to any table row within the `<tbody>.`',
@@ -32,6 +34,7 @@ const DataTableTemplate = (args) => ({
         headers,
         isLoading,
         items,
+        keepSelectedOnChange,
         selectionMode,
         hideHeader,
         hideLabelActionsBreakpoint,
@@ -60,6 +63,7 @@ export default {
     hideLabelActionsBreakpoint: null,
     isLoading: false,
     items: [],
+    keepSelectedOnChange: false,
     selectionMode: 'single',
     striped: false,
   },
@@ -103,6 +107,13 @@ export default {
     items: {
       name: 'items',
       description: description.items,
+    },
+    keepSelectedOnChange: {
+      name: 'isLoading',
+      description: description.keepSelectedOnChange,
+      control: {
+        type: 'boolean',
+      },
     },
     selectionMode: {
       name: 'selectionMode',
@@ -315,6 +326,7 @@ export const Slots = (args) => ({
           headers,
           isLoading,
           items,
+          keepSelectedOnChange,
           selectionMode,
           hideHeader,
           striped

--- a/src/components/DataTable/components/SbDataTableActions.js
+++ b/src/components/DataTable/components/SbDataTableActions.js
@@ -17,9 +17,9 @@ export const SbDataTableActions = {
       type: Number,
       default: null,
     },
-    selectedRowsLength: {
-      type: Number,
-      default: 0,
+    selectedRows: {
+      type: Array,
+      default: [],
     },
   },
 
@@ -33,6 +33,10 @@ export const SbDataTableActions = {
     labelSelectedRowsLength() {
       const labelItem = this.selectedRowsLength > 1 ? 'items' : 'item'
       return `${this.selectedRowsLength} ${labelItem} selected`
+    },
+
+    selectedRowsLength() {
+      return this.selectedRows.length
     },
   },
 

--- a/src/components/DataTable/components/SbDataTableBody.js
+++ b/src/components/DataTable/components/SbDataTableBody.js
@@ -29,7 +29,9 @@ export const SbDataTableBodyRow = {
     },
 
     isSelected() {
-      return this.selectedRows.some((row) => row === this.row)
+      return this.selectedRows.some(
+        (row) => JSON.stringify(row) === JSON.stringify(this.row)
+      )
     },
   },
 

--- a/src/components/DataTable/components/SbDataTableHeader.js
+++ b/src/components/DataTable/components/SbDataTableHeader.js
@@ -114,8 +114,9 @@ export const SbDataTableHeaderRow = {
     headers: {
       type: Array,
     },
-    selectedRowsLength: {
-      type: Number,
+    selectedRows: {
+      type: Array,
+      default: [],
     },
     selectionMode: {
       type: String,
@@ -129,8 +130,13 @@ export const SbDataTableHeaderRow = {
     context() {
       return this.dataTableContext()
     },
+
     isIndeterminate() {
       return !this.allRowsSelected && !!this.selectedRowsLength
+    },
+
+    selectedRowsLength() {
+      return this.selectedRows.length
     },
   },
 
@@ -199,9 +205,9 @@ export const SbDataTableHeader = {
       required: false,
       type: Array,
     },
-    selectedRowsLength: {
-      required: false,
-      type: Number,
+    selectedRows: {
+      type: Array,
+      deafult: [],
     },
     selectionMode: {
       required: false,
@@ -220,7 +226,7 @@ export const SbDataTableHeader = {
           allowSelection: this.allowSelection,
           allRowsSelected: this.allRowsSelected,
           headers: this.headers,
-          selectedRowsLength: this.selectedRowsLength,
+          selectedRows: this.selectedRows,
           selectionMode: this.selectionMode,
           sortedKey: this.sortedKey,
         },

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -55,7 +55,15 @@ const SbDataTable = {
       type: Boolean,
       default: false,
     },
+    keepSelectedOnChange: {
+      type: Boolean,
+      default: false,
+    },
     items: {
+      type: Array,
+      default: () => [],
+    },
+    selectedItems: {
       type: Array,
       default: () => [],
     },
@@ -76,7 +84,10 @@ const SbDataTable = {
       if (this.selectionMode === 'single' || !this.selectedRows.length)
         return false
 
-      return this.selectedRows.length === this.items.length ? true : null
+      return this.selectedRows.length === this.items.length &&
+        this.hasSelectedRowsInList.length
+        ? true
+        : null
     },
 
     dataTableContext() {
@@ -90,6 +101,14 @@ const SbDataTable = {
         // method to control sorting
         toggleTableOrder: this.toggleTableOrder,
       }
+    },
+
+    hasSelectedRowsInList() {
+      return this.items.filter((item) =>
+        this.selectedRows.some(
+          (row) => JSON.stringify(item) === JSON.stringify(row)
+        )
+      )
     },
 
     showHeader() {
@@ -106,7 +125,9 @@ const SbDataTable = {
 
   watch: {
     items() {
-      this.deselectAll()
+      if (!this.keepSelectedOnChange) {
+        this.deselectAll()
+      }
     },
 
     selectedRows(value) {
@@ -154,7 +175,7 @@ const SbDataTable = {
         this.selectedRows.push(row)
 
         this.selectedRows = this.items.filter((item) => {
-          return this.selectedRows.indexOf(item) > -1
+          return this.hasSelectedRowsInList.indexOf(item) > -1
         })
       }
     },
@@ -208,7 +229,7 @@ const SbDataTable = {
         props: {
           actions: this.actions,
           hideLabelActionsBreakpoint: this.hideLabelActionsBreakpoint,
-          selectedRowsLength: this.selectedRows.length,
+          selectedRows: this.hasSelectedRowsInList,
         },
         on: {
           click: (value) => this.$emit('emit-action', value),
@@ -280,7 +301,7 @@ const SbDataTable = {
                 allowSelection: this.allowSelection,
                 headers: [...headerData],
                 row: tableRow,
-                selectedRows: this.selectedRows,
+                selectedRows: this.hasSelectedRowsInList,
               },
             },
             columns
@@ -300,7 +321,7 @@ const SbDataTable = {
                   allowSelection: this.allowSelection,
                   allRowsSelected: this.allRowsSelected,
                   headers: this.headers,
-                  selectedRowsLength: this.selectedRows.length,
+                  selectedRows: this.hasSelectedRowsInList,
                   selectionMode: this.selectionMode,
                   sortedKey: this.sortKey,
                 },
@@ -312,7 +333,7 @@ const SbDataTable = {
                   allowSelection: this.allowSelection,
                   headers: this.headers,
                   items: this.sortedData,
-                  selectedRows: this.selectedRows,
+                  selectedRows: this.hasSelectedRowsInList,
                 },
               })
             : null,
@@ -324,7 +345,7 @@ const SbDataTable = {
                         allowSelection: this.allowSelection,
                         allRowsSelected: this.allRowsSelected,
                         headers: [...headerData],
-                        selectedRowsLength: this.selectedRows.length,
+                        selectedRows: this.hasSelectedRowsInList,
                         selectionMode: this.selectionMode,
                         sortedKey: this.sortKey,
                       },
@@ -347,7 +368,7 @@ const SbDataTable = {
         },
       },
       [
-        this.selectedRows.length > 0 && renderActions(),
+        this.hasSelectedRowsInList.length > 0 && renderActions(),
         renderTable(),
         this.isLoading && renderLoading(),
       ]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [WORK-57](https://storyblok.atlassian.net/browse/WORK-57)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

I've recorded a video to show, it's not possible to see in action because we have to update the DS hash on develop before. When I click on Move button, I change the `keepSelectedOnChange` property to `true`, so, as you can see, returning to root folder where the rows was selected, I keep them selected.

https://user-images.githubusercontent.com/11169758/159531093-1953e118-98c4-4a79-9e05-99da5e337b54.mp4


## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- In this PR, I've created a new property called `keepSelectedOnChange`, to save the selected rows in memory in case there is a change of items, and selects the items again when reloading the same list.
