### PR TITLE
Task/ON-361: DataTable selection only when click on checkbox

### DIFF
--- a/src/components/DataTable/DataTable.stories.js
+++ b/src/components/DataTable/DataTable.stories.js
@@ -5,7 +5,7 @@ import SbAvatarGroup from '../AvatarGroup'
 const description = {
   actions:
     'It must be an array of objects representing the action buttons. Each object must have a `label` (which is the button label) and a `value` (which is the value that will be emitted in the `emit-action` event). You can also add an `icon` property to the object.',
-  allowSelection: 'Allow row selection.',
+  allowSelection: 'Allows row selection when clicking on the checkbox.',
   actionsMenu: 'Select a row to show the actions menu',
   component:
     'Data tables are used to organize and display data efficiently. `SbDataTable` component allows for customization with additional functionality, as needed by your product’s users.',

--- a/src/components/DataTable/components/SbDataTableBody.js
+++ b/src/components/DataTable/components/SbDataTableBody.js
@@ -58,9 +58,6 @@ export const SbDataTableBodyRow = {
           'sb-data-table__row--selected':
             this.isSelected && this.allowSelection,
         },
-        on: {
-          click: this.handleRowSelected,
-        },
       },
       [
         this.allowSelection &&
@@ -69,6 +66,9 @@ export const SbDataTableBodyRow = {
             {
               staticClass: 'sb-data-table__body-cell',
               class: 'sb-data-table__col-selection',
+              on: {
+                click: this.handleRowSelected,
+              },
             },
             [
               h(SbCheckbox, {

--- a/src/components/DataTable/data-table.scss
+++ b/src/components/DataTable/data-table.scss
@@ -1,4 +1,13 @@
 .sb-data-table {
+  &__col-selection,
+  &__head-cell {
+    .sb-checkbox__inner:hover {
+      .sb-checkbox__input {
+        box-shadow: 0 0 0 2px rgba(217, 244, 243, 1);
+      }
+    }
+  }
+
   &__loading {
     position: absolute;
     bottom: 0;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [ON-361](https://storyblok.atlassian.net/browse/ON-361)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->



## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- When the DataTable has the `allow-selection` prop, the selection of the row only happens when clicking on the checkbox
- Added hover styles for the checkbox

## Other information

Currently we have to add `@click.stop` (for example) to the DataTable item that we don’t want to perform the selection when allow-selection is true, which ends up affecting following methods, etc. After this PR, there will be no need for this.
