### PR TITLE
bugfix(int-304): In SBSelect, remove the scrollbar and check if the large options view works

### DIFF
--- a/src/components/Select/select.scss
+++ b/src/components/Select/select.scss
@@ -175,7 +175,7 @@
 
   &__value {
     position: absolute;
-    overflow-x: hidden;
+    overflow: hidden;
     box-sizing: border-box;
     max-width: calc(100% - 60px);
     text-overflow: ellipsis;
@@ -183,6 +183,7 @@
 
     &-icon-left {
       margin-left: 35px;
+      max-width: calc(100% - 80px);
     }
   }
 

--- a/src/components/Select/select.scss
+++ b/src/components/Select/select.scss
@@ -180,6 +180,7 @@
     max-width: calc(100% - 60px);
     text-overflow: ellipsis;
     white-space: nowrap;
+    line-height: normal;
 
     &-icon-left {
       margin-left: 35px;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
This PR fixes the issue that Ademar reported where all selections were scrolling.
<img width="884" alt="Screen Shot 2022-03-28 at 14 33 48" src="https://user-images.githubusercontent.com/8209305/160634097-e7bad107-a489-486b-b4c5-098fbbbd863b.png">

## Pull request type

Jira Link: [INT-304: In SBSelect: Remove the scrollbar and check if the large options view works](https://storyblok.atlassian.net/browse/INT-304)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

- To test this PR, you first need to change a system preference on mac:
Go to System Preferences > General > Show Scroll bars > Check Always

- Then access the Blok.ink generated by vercel and go to:
Menu > Components > Form > SbSelect > Default
Select an option and verify that the scroll bar is not displayed.

- Still in the SbSelect Default, add a longer description to the option at:
Control > Props > Options
Check that the text does not exceed the limits of the select box.

- Do the same tests for SbSelect > With Icon.

## Other information
I am available for any questions or suggestions! 