### PR TITLE
bugfix(INT-341): Adjusting the datepicker so that the last day of previous month appears

### DIFF
--- a/src/components/Datepicker/components/DatepickerDays.vue
+++ b/src/components/Datepicker/components/DatepickerDays.vue
@@ -39,7 +39,7 @@ export default {
       const days = []
 
       for (let i = this.$_getDayInWeek(firstDate); i > 1; i--) {
-        const dateValue = firstDate.subtract(i, 'day')
+        const dateValue = firstDate.subtract(i - 1, 'day')
 
         days.push({
           label: dateValue.date(),
@@ -87,6 +87,7 @@ export default {
      */
     $_getDayInWeek(dayJsInstance) {
       const _day = dayJsInstance.day()
+      debugger
       return _day === 0 ? 7 : _day
     },
   },

--- a/src/components/Datepicker/components/DatepickerDays.vue
+++ b/src/components/Datepicker/components/DatepickerDays.vue
@@ -87,7 +87,6 @@ export default {
      */
     $_getDayInWeek(dayJsInstance) {
       const _day = dayJsInstance.day()
-      debugger
       return _day === 0 ? 7 : _day
     },
   },


### PR DESCRIPTION
This PR adjusts the picker so that the last day of the previous month appears correctly.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-341 - [V2][DesignSystem] - SbDatepicker: the last month appears with 1 day less.](https://storyblok.atlassian.net/browse/INT-341)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Go to:
Menu > Components > Form > SbDatepicker
Check that the last day of the previous month is displaying correctly, for example, open the datepicker and check that the last day of March is the 31st.
Please check some months from different years.

## Other information
Any questions or suggestions, I'm available!
