### PR TITLE
bugfix(WORK-284): User Profile initials are not centralized to its circle

### DIFF
--- a/src/components/Avatar/avatar.scss
+++ b/src/components/Avatar/avatar.scss
@@ -29,6 +29,7 @@
     color: $white;
     font-size: $font-12;
     font-weight: $font-weight-medium;
+    line-height: normal;
     text-align: center;
     text-transform: uppercase;
   }

--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -30,10 +30,10 @@
             size="small"
             :name="tagLabel[itemLabel]"
           />
-          <span v-else-if="!showSubtitle">{{ tagLabel[itemLabel] }}</span>
-          <span v-else
-            >{{ tagLabel[itemLabel] }} ({{ tagLabel[itemSubtitle] }})</span
-          >
+          <span v-if="showSubtitle">
+            {{ tagLabel[itemLabel] }} ({{ tagLabel[itemSubtitle] }})
+          </span>
+          <span v-else>{{ tagLabel[itemLabel] }}</span>
         </template>
       </SbTag>
       <input


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [WORK-284](https://storyblok.atlassian.net/browse/WORK-284)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

How to reproduce it:

1 - Access any Space configuration;
2 - Access Workflow options;
3 - In "Defined stage, select a stage and go to settings;
4 - At the “Users/Roles who can change the stage Drafting to the next available stage” option, select “Specific users/roles”and after, Assigned roles and check users;
5 - Use "Storyblok team demo space” space, to do so;

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The user initial is centralized vertically and horizontally.

