### PR TITLE
hotfix(sbTooltip): add word-break int-344

### DIFF
--- a/src/components/Tooltip/tooltip.scss
+++ b/src/components/Tooltip/tooltip.scss
@@ -68,6 +68,7 @@
   line-height: 15px;
   border-radius: 2px;
   box-shadow: 0 0 2px 1px rgba(0, 0, 0, 0.08);
+  word-break: break-word;
 
   &--dark {
     color: $white;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Add work break in SbTooltip.
## Pull request type

Jira Link: [INT-344 - [HOTFIX] [Design System] [Directives > Vtooltip > Default] the tooltip text gets incorrectly truncated if the string does not include a space](https://storyblok.atlassian.net/browse/INT-344)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Go to the DS: https://blok.ink/?path=/docs/design-system-directives-vtooltip--default 

Type in a long text without any spaces into the “label” field, examples:
`thisisatxtwithoutanyspaceadded`
`ThisIsAtxtWithoutAnySpaceAddThisIs`
`@txtWithoutAnySpaceAddThisIs`
`@txtWithoutAnySpaceLimitThisIs@txtWithoutAnySpace!!!!!!`

Add too normal long text, for example:
Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. 
<!-- Please provide the steps on how to test this PR. -->


## Other information
Any questions, I'm here!