### PR TITLE
bugfix(sbUploadDialog): Fix modal blocking in SbUploadDialog docs int-41

### DIFF
--- a/src/components/UploadDialog/UploadDialog.stories.js
+++ b/src/components/UploadDialog/UploadDialog.stories.js
@@ -4,7 +4,8 @@ export default {
   title: 'Design System/Components/SbUploadDialog',
   component: SbUploadDialog,
   parameters: {
-    docs: { inlineStories: false },
+    docs: { inlineStories: false, iframeHeight: 300 },
+    layout: 'fullscreen',
   },
   args: {
     currentFile: 1,

--- a/src/components/UploadDialog/UploadDialog.stories.js
+++ b/src/components/UploadDialog/UploadDialog.stories.js
@@ -3,6 +3,9 @@ import SbUploadDialog from '.'
 export default {
   title: 'Design System/Components/SbUploadDialog',
   component: SbUploadDialog,
+  parameters: {
+    docs: { inlineStories: false },
+  },
   args: {
     currentFile: 1,
     currentFileName: 'test.png',


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
This PR fixes modal blocking in SbUploadDialog component docs.

## Pull request type

Jira Link: [INT-41 - Error on Design System's showcase for SbUploadDialog](https://storyblok.atlassian.net/browse/INT-41)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Open the SbUploadDialog component Docs in [blok.ink](http://localhost:6006/?path=/docs/design-system-components-sbuploaddialog--default) and check if the modal is inside the iframe without blocking the whole page.

Before correction:
![Screen Shot 2021-11-24 at 17 41 12](https://user-images.githubusercontent.com/8209305/168073044-0a98dd0a-3406-4517-84ec-a9789f36e6ca.png)

After correction:
![Captura de Tela 2022-05-12 às 09 17 44](https://user-images.githubusercontent.com/8209305/168073069-bbcd64e0-96bf-44b5-948a-ef300230096e.png)

Note: The Docs tab zoom doesn't work very well when we disable the inlineStories property. I had to disable it so that the modal wouldn't lock the rest of the screen. The zoom issue is a storybook issue and I couldn't find a solution for it. Given this, I talked to the team and the PO to release this task with this observation.

## Other information
Any problem, I'm available.