### PR TITLE
bugfix(sbTextField): add support for firefox sbTextField height INT-389

### DIFF
--- a/src/components/TextField/textfield.scss
+++ b/src/components/TextField/textfield.scss
@@ -48,6 +48,7 @@
   &__input {
     padding: 13.5px 17px;
   }
+
   &__textarea {
     padding: 15px 17px;
   }
@@ -194,6 +195,14 @@
 
     &--warning {
       color: $orange;
+    }
+  }
+}
+
+@supports (-moz-appearance:none) {
+  .sb-textfield {
+    &__input {
+      padding: 13px 17px;
     }
   }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
In this PR I add support in css so that the height of the input is at 45px in firefox.
## Pull request type

Jira Link: [INT-389 - Input height fix](https://storyblok.atlassian.net/browse/INT-389)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
In Firefox, go in:
https://storyblok-design-system-git-bugfix-int-389-1c1d51-storyblok-com.vercel.app/?path=/story/design-system-components-form-sbtextfield--default

Inspect the element and make sure the height is at 45px.
![Captura de Tela 2022-05-13 às 16 00 04](https://user-images.githubusercontent.com/8209305/168366622-9da2d73a-6c7c-4ed7-8865-d31053e3a70c.png)

## Other information
Any questions, I'm here!