### PR TITLE
feat(sidebar): collapse/expand sidebar automatically depending on the…

### DIFF
--- a/src/components/Sidebar/Sidebar.stories.js
+++ b/src/components/Sidebar/Sidebar.stories.js
@@ -64,6 +64,7 @@ const SidebarTemplate = (args) => ({
       v-bind="{ listItems }"
       :logo="logo"
       :minimize.sync="internalMinimize"
+      :max-width="maxWidth"
     >
       <SbSidebarListItem
         icon="partner-team"
@@ -131,6 +132,7 @@ export default {
     listItems: [...listItemsData],
     minimize: false,
     logo: '',
+    maxWidth: null,
   },
   argTypes: {
     minimize: {
@@ -172,4 +174,19 @@ export const CustomLogo = SidebarTemplate.bind({})
 
 CustomLogo.args = {
   logo: 'https://bcassetcdn.com/social/bvrg7kkg12/preview.png',
+}
+
+export const MaxWidth = SidebarTemplate.bind({})
+
+MaxWidth.args = {
+  maxWidth: '800px',
+}
+
+MaxWidth.parameters = {
+  docs: {
+    description: {
+      story:
+        'When setting the `maxWidth` value, the sidebar will automatically collapse/expand when the window width is equal or lower than and greater than.',
+    },
+  },
 }

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -86,6 +86,11 @@ export default {
       type: String,
       default: '',
     },
+    maxWidth: {
+      type: String,
+      default: '1000px',
+      required: false,
+    },
   },
 
   data: () => ({
@@ -95,6 +100,7 @@ export default {
   }),
 
   mounted() {
+    this.toggleSidebar()
     this.createObserver()
   },
 
@@ -126,10 +132,14 @@ export default {
         this.sizeObserver = new ResizeObserver(() => {
           this.checkScrollbar()
         })
+
         this.sizeObserver.observe(
           document.getElementsByClassName('sb-sidebar-list__container')[0]
         )
       }
+
+      // Used onresize here because if we observe a certain element with Resize Observer when manually expanding/collapsing the sidebar, it has no effect
+      window.onresize = () => this.toggleSidebar()
     },
 
     checkScrollbar() {
@@ -138,6 +148,13 @@ export default {
       )[0]
       if (list) {
         this.hasScrollbar = list.scrollHeight > list.clientHeight
+      }
+    },
+
+    toggleSidebar() {
+      if (window.matchMedia) {
+        const maxWidth = `(max-width: ${this.maxWidth})`
+        this.$emit('update:minimize', window.matchMedia(maxWidth).matches)
       }
     },
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Access the application and make sure that the sidebar automatically collapses when the screen is smaller than 1000px and that it expands when the screen is wider than 1000px.

Also make sure that the user can manually collapse/expand it at any time.

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Introduce a callback to the `onresize` function that is triggered whenever the window is resized to automatically collapse/extend the left sidebar

## Other information
