### PR TITLE
hotfix( int-397): fix text overlaying iconsbTextField

### DIFF
--- a/src/components/TextField/textfield.scss
+++ b/src/components/TextField/textfield.scss
@@ -202,7 +202,8 @@
 @supports (-moz-appearance:none) {
   .sb-textfield {
     &__input {
-      padding: 13px 17px;
+      padding-top: 13px;
+      padding-bottom: 13px;
     }
   }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Fix text that is overlapping the icons in the input in the Firefox browser.

## Pull request type

Jira Link: [INT-397 - [DS]- HOTFIX - Text overlaying icon in SbTextField](https://storyblok.atlassian.net/browse/INT-397)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
In Firefox, go to https://storyblok-design-system-5ewvion22-storyblok-com.vercel.app/?path=/story/design-system-components-form-sbtextfield--with-icon
Check that the Sbtextfield text is not overlapping the icons in the Firefox browser.
 

## Other information
Any questions, I'm here!