### PR TITLE
bugfix(sbModal): INT-181 - remove event listener 

### DIFF
--- a/src/components/Modal/SbModal.vue
+++ b/src/components/Modal/SbModal.vue
@@ -134,20 +134,28 @@ export default {
 
   created() {
     this.$_createPortalInstance()
-    this.handleCloseModalByPressingEsc()
   },
 
   methods: {
+    escapeEventListener(e) {
+      if (e.key === 'Escape') {
+        this.handleCloseModal()
+      }
+    },
+
+    removeListener() {
+      window.removeEventListener('keydown', this.escapeEventListener)
+    },
+
+    registerListener() {
+      window.addEventListener('keydown', this.escapeEventListener)
+    },
     /**
      * handler for closing the modal by pressing ESC on the keyboard
      */
     handleCloseModalByPressingEsc() {
       if (this.escCloses) {
-        window.addEventListener('keydown', (e) => {
-          if (e.key === 'Escape') {
-            this.handleCloseModal()
-          }
-        })
+        this.registerListener()
       }
     },
     /**
@@ -155,6 +163,7 @@ export default {
      */
     handleCloseModal() {
       if (this.open && this.escCloses) {
+        this.removeListener()
         this.open = false
         this.$nextTick(() => {
           document.querySelector('body').style.overflow = 'auto'
@@ -168,6 +177,7 @@ export default {
      */
     handleOpenModal() {
       if (!this.open) {
+        this.handleCloseModalByPressingEsc()
         this.open = true
         this.$nextTick(() => {
           document.querySelector('body').style.overflow = 'hidden'


### PR DESCRIPTION
In this PR we reduced the amount of event listener instantiated in SbModal.
Before, when creating the component, the "handleCloseModalByPressingEsc" method was called, so that even without opening the modal it had already been instantiated, now we only call this method when opening the modal and when we close it, we remove the event listener.
## Pull request type

Jira Link: [INT-181 - Design System: Remove Event Listener on destroy component](https://storyblok.atlassian.net/browse/INT-181)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
In https://storyblok-design-system-git-fix-int-181-re-3696bb-storyblok-com.vercel.app/?path=/story/design-system-components-sbmodal--default:

-  Open modal component in new tab:
![Captura de Tela 2022-05-23 às 09 45 14](https://user-images.githubusercontent.com/8209305/169822781-1441221d-f723-4041-b98a-9a215298cb3a.png)
- In the new tab, open the browser console and make sure there is only one Listener "keydown" event.
`getEventListeners(window)['keydown']`
![Captura de Tela 2022-05-23 às 09 46 25](https://user-images.githubusercontent.com/8209305/169823134-f3a6b52d-48f5-463e-97e2-bd7da4321a58.png)
- Open the modal and check for two keydown event listeners:
![Captura de Tela 2022-05-23 às 09 47 14](https://user-images.githubusercontent.com/8209305/169823262-86d489c5-d090-43d5-8ed2-17bc89c1ab74.png)
- Close the modal and check if we're back to having only one event listener.

## Other information
Note: The task says that the SbSlideover also needed to remove the event listener from the SbSlideover, but I have verified that this is currently being done.

Any questions, I'm here!
