### PR TITLE
bugfix(INT-23):  Fix blocked docs tab in SbLoading and SbDropArea components

### DIFF
--- a/src/components/DropArea/DropArea.stories.js
+++ b/src/components/DropArea/DropArea.stories.js
@@ -5,11 +5,14 @@ export default {
   title: 'Design System/Components/SbDropArea',
   parameters: {
     docs: {
+      inlineStories: false,
+      iframeHeight: 400,
       description: {
         component:
           'The `SbDropArea` component serves as a container for uploading files, works with the drop file event, and issues a callback with the files, you must implement the upload function because the component does not have the same!',
       },
     },
+    layout: 'fullscreen',
   },
   args: {
     accept: '',

--- a/src/components/Loading/Loading.stories.js
+++ b/src/components/Loading/Loading.stories.js
@@ -24,6 +24,7 @@ export default {
   component: SbLoading,
   parameters: {
     docs: {
+      inlineStories: false,
       description: {
         component:
           'Loading spinners are used when retrieving data or performing slow computations, and help to notify users that loading is underway.',
@@ -100,7 +101,6 @@ export const ProgressBar = (args) => ({
   components: { SbLoading },
   props: Object.keys(args),
   template: `
-    <div>
       <SbLoading
         v-bind="{
           type,
@@ -109,7 +109,6 @@ export const ProgressBar = (args) => ({
           showPercentage
         }"
       />
-    </div>
   `,
 })
 
@@ -175,6 +174,7 @@ export const SpinnerWithSizes = (args) => ({
 
 SpinnerWithSizes.parameters = {
   docs: {
+    iframeHeight: 200,
     description: {
       story:
         'When passing the prop `spinner` the component starts to render an animated spinner',
@@ -187,76 +187,62 @@ export const SpinnerWithPercentage = (args) => ({
   props: Object.keys(args),
   template: `
     <div>
-      <SbLoading
-        v-bind="{
-          type: 'spinner',
-          size: 'small',
-          value: 25,
-          showPercentage: true,
-          color
-        }"
-      />
-      <SbLoading
-        v-bind="{
-          type: 'spinner',
-          size: 'normal',
-          value: 25,
-          showPercentage: true,
-          color
-        }"
-      />
-      <SbLoading
-        v-bind="{
-          type: 'spinner',
-          size: 'large',
-          value: 25,
-          showPercentage: true,
-          color
-        }"
-      />
-      <SbLoading
-        v-bind="{
-          type: 'spinner',
-          size: 'x-large',
-          value: 25,
-          showPercentage: true,
-          color
-        }"
-      />
+      <div style="margin-bottom: 15px">
+        <SbLoading
+          v-bind="{
+            type: 'spinner',
+            size: 'small',
+            value: 25,
+            showPercentage: true,
+            color
+          }"
+        />
+      </div>
+      <div style="margin-bottom: 15px">
+        <SbLoading
+          v-bind="{
+            type: 'spinner',
+            size: 'normal',
+            value: 25,
+            showPercentage: true,
+            color
+          }"
+        />
+      </div>
+      <div style="margin-bottom: 15px">
+        <SbLoading
+          v-bind="{
+            type: 'spinner',
+            size: 'large',
+            value: 25,
+            showPercentage: true,
+            color
+          }"
+        />
+      </div>
+      <div style="margin-bottom: 15px">
+        <SbLoading
+          v-bind="{
+            type: 'spinner',
+            size: 'x-large',
+            value: 25,
+            showPercentage: true,
+            color
+          }"
+        />
+      </div>
     </div>
   `,
 })
 
 SpinnerWithPercentage.parameters = {
   docs: {
+    iframeHeight: 300,
     description: {
       story:
         'The spinners also show the percentage of the loanding, pass the `showPercentage` property so that the percentage is shown.',
     },
   },
-}
-
-export const BlockingUiLoadingSpinner = LoadingTemplate.bind({})
-
-BlockingUiLoadingSpinner.args = {
-  uiBlock: true,
-  size: 'x-large',
-}
-
-BlockingUiLoadingSpinner.parameters = {
-  docs: {
-    description: {
-      story:
-        'The `uiBlock` feature causes the user`s screen to be blocked during loading.',
-    },
-  },
-}
-
-export const BlockingUiLoadingProgressBar = LoadingTemplate.bind({})
-
-BlockingUiLoadingProgressBar.args = {
-  uiBlock: true,
-  type: 'bar',
 }
 
 export const LoadingWithPlaceholder = (args) => ({

--- a/src/components/Loading/LoadingBlockUi.stories.js
+++ b/src/components/Loading/LoadingBlockUi.stories.js
@@ -30,6 +30,7 @@ export default {
           'Loading spinners are used when retrieving data or performing slow computations, and help to notify users that loading is underway.',
       },
     },
+    layout: 'fullscreen',
   },
   args: {
     type: 'spinner',

--- a/src/components/Loading/LoadingBlockUi.stories.js
+++ b/src/components/Loading/LoadingBlockUi.stories.js
@@ -1,0 +1,120 @@
+import { SbLoading } from './index'
+import { availableColors } from '../../utils'
+import { loadingTypes, loadingSizes } from './utils'
+
+const LoadingBlockTemplate = (args) => ({
+  components: { SbLoading },
+  props: Object.keys(args),
+  template: `
+    <SbLoading
+      v-bind="{
+        type,
+        size,
+        value,
+        showPercentage,
+        color,
+        uiBlock
+      }"
+    />
+  `,
+})
+
+export default {
+  title: 'Design System/Components/SbLoading',
+  component: SbLoading,
+  parameters: {
+    docs: {
+      inlineStories: false,
+      description: {
+        component:
+          'Loading spinners are used when retrieving data or performing slow computations, and help to notify users that loading is underway.',
+      },
+    },
+  },
+  args: {
+    type: 'spinner',
+    size: 'normal',
+    value: 0,
+    showPercentage: false,
+    color: 'primary',
+    uiBlock: false,
+  },
+  argTypes: {
+    type: {
+      name: 'type',
+      description:
+        'With the prop `type` you can choose which type of loading will be rendered.',
+      control: {
+        type: 'select',
+        options: [...loadingTypes],
+      },
+    },
+    size: {
+      name: 'size',
+      description:
+        'With the prop `size` you can define the sizes of the component loading.',
+      control: {
+        type: 'select',
+        options: [...loadingSizes],
+      },
+    },
+    value: {
+      name: 'value',
+      description:
+        'The prop `value` must be entered to change the loading status, it ranges from 0 to 100.',
+      control: {
+        type: 'range',
+        options: [0, 100, 1], // [min, max, step]
+      },
+    },
+    showPercentage: {
+      name: 'show-percentage',
+      description:
+        'With the prop `show-percentage` you can choose whether you want the loading percentage to appear or not.',
+      control: {
+        type: 'boolean',
+      },
+    },
+    color: {
+      name: 'color',
+      description:
+        'Select the color of the loading spinner with the colors available in our Desing system.',
+      control: {
+        type: 'select',
+        options: availableColors,
+      },
+    },
+    uiBlock: {
+      name: 'uiBlock',
+      description:
+        'With this property the user`s ui will be locked when starting loading.',
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+}
+
+export const BlockingUiLoadingSpinner = LoadingBlockTemplate.bind({})
+
+BlockingUiLoadingSpinner.args = {
+  uiBlock: true,
+  size: 'x-large',
+}
+
+BlockingUiLoadingSpinner.parameters = {
+  docs: {
+    description: {
+      story:
+        'The `uiBlock` feature causes the user`s screen to be blocked during loading.',
+    },
+  },
+}
+
+export const BlockingUiLoadingProgressBar = LoadingBlockTemplate.bind({})
+
+BlockingUiLoadingProgressBar.args = {
+  uiBlock: true,
+  type: 'bar',
+  value: 30,
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
This PR fixes the locked documents tab in the SbLoading and SbDropArea components.

Comments: 
- In SbLoading I had to create a new story file because even setting the inlineStories attribute to false BlockUI stories blocked all screen actions, when I separated them, the features worked correctly again. I believe that the BlockUI used within SbLoading was overlapping the other examples of using the components.
- The task says that the error occurred in 3 components SbDropArea, SbLoading and SbUploadDialog, but SbUploadDialog has been fixed in [this PR](#205).

## Pull request type

Jira Link: [INT-23 - In blok.ink/, it is not possible to view the options code SbDropArea SbLoading SbUploadDialog](https://storyblok.atlassian.net/browse/INT-23)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Open the components mentioned above and check that the Docs tab is not blocked.

## Other information
Any problem, I'm available.