### PR TITLE
fix(work-252): fixes SbSlideover animation when clicking cancel button outside the component

### DIFF
--- a/src/components/Slideover/Slideover.vue
+++ b/src/components/Slideover/Slideover.vue
@@ -63,7 +63,7 @@ export default {
       if (state) {
         this.handleOpenSlide()
       } else {
-        this.handleCloseSlide()
+        this.openSlideover = false
       }
     },
     preventClose(state) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Access: https://storyfront-develop-git-subtask-work-252-storyblok-com.vercel.app/#/login
- Go to Settings > Users > Add new user
- Click in cancel button below the SbSlideover and check if the animation runs correctly

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now, clicking on an external cancel button on SbSlideover, does the animation correctly to close the component.
