### PR TITLE
fix(str-974): One line minibrowser slugs

### DIFF
--- a/src/components/Minibrowser/Minibrowser.stories.js
+++ b/src/components/Minibrowser/Minibrowser.stories.js
@@ -6,76 +6,93 @@ export const MOCK_DATA = {
   FIRST_LEVEL: [
     {
       label: 'Landing Page',
+      subtitle: 'landing-page',
       isParent: true,
       value: '1.0',
     },
     {
       label: 'Case Studies',
+      subtitle: 'case-studies',
       value: '1.1',
     },
     {
       label: 'Jobs',
+      subtitle: 'jobs',
       value: '1.2',
     },
     {
       label: 'Quotes',
+      subtitle: 'quotes',
       value: '1.3',
     },
     {
       label: 'Plugin',
+      subtitle: 'plugin',
       value: '1.4',
     },
     {
       label: 'About',
+      subtitle: 'about',
       value: '1.5',
     },
     {
       label: 'Pricing',
+      subtitle: 'pricing',
       value: '1.6',
     },
     {
       label: 'Stories',
+      subtitle: 'stories',
       value: '1.7',
     },
     {
       label: 'Marketing',
+      subtitle: 'marketing',
       value: '1.8',
     },
     {
       label: 'Open Source',
+      subtitle: 'open-source',
       value: '1.9',
     },
   ],
   SECOND_LEVEL: [
     {
       isParent: true,
-      label: 'PPC',
+      label: 'PPC',
+      subtitle: 'ppc',
       value: '2.0',
     },
     {
       label: 'Hp v1',
+      subtitle: 'hp-v1',
       value: '2.1',
     },
     {
       label: 'Hp v2',
+      subtitle: 'hp-v2',
       value: '2.2',
     },
     {
       label: 'Hp v3',
+      subtitle: 'hp-v3',
       value: '2.3',
     },
   ],
   THIRD_LEVEL: [
     {
       label: 'e-commerce',
+      subtitle: 'e-commerce',
       value: '3.0',
     },
     {
       label: 'for-developers',
+      subtitle: 'for-developers',
       value: '3.1',
     },
     {
       label: 'for-content-writers',
+      subtitle: 'for-content-writers',
       value: '3.2',
     },
   ],
@@ -264,9 +281,11 @@ WithGroups.args = {
       items: [
         {
           label: 'Case Studies',
+          subtitle: 'case-studies',
         },
         {
           label: 'Jobs',
+          subtitle: 'jobs',
         },
       ],
     },
@@ -324,9 +343,11 @@ WithGroupsSlot.args = {
       items: [
         {
           label: 'Case Studies',
+          subtitle: 'case-studies',
         },
         {
           label: 'Jobs',
+          subtitle: 'jobs',
         },
       ],
     },
@@ -376,9 +397,11 @@ Inline.args = {
       items: [
         {
           label: 'Case Studies',
+          subtitle: 'case-studies',
         },
         {
           label: 'Jobs',
+          subtitle: 'jobs',
         },
       ],
     },

--- a/src/components/Minibrowser/Minibrowser.stories.js
+++ b/src/components/Minibrowser/Minibrowser.stories.js
@@ -59,7 +59,7 @@ export const MOCK_DATA = {
   SECOND_LEVEL: [
     {
       isParent: true,
-      label: 'PPC',
+      label: 'PPC',
       subtitle: 'ppc',
       value: '2.0',
     },

--- a/src/components/Minibrowser/minibrowser.scss
+++ b/src/components/Minibrowser/minibrowser.scss
@@ -86,6 +86,7 @@ $full-height-padding: $general-padding - $padding-full-height-difference;
     &-container {
       flex: 1;
       overflow: hidden;
+      line-height: normal;
     }
 
     &-name {

--- a/src/components/Minibrowser/minibrowser.scss
+++ b/src/components/Minibrowser/minibrowser.scss
@@ -85,6 +85,7 @@ $full-height-padding: $general-padding - $padding-full-height-difference;
 
     &-container {
       flex: 1;
+      overflow: hidden;
     }
 
     &-name {
@@ -95,9 +96,12 @@ $full-height-padding: $general-padding - $padding-full-height-difference;
 
     &-subtitle {
       display: block;
+      overflow: hidden;
       margin-top: 2px;
       color: $light-gray;
       font-size: $font-12;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     &-icon {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [STR-974](https://storyblok.atlassian.net/browse/STR-974)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
1. In the `Content` tab of a Space create a folder or a Story with a very long slug
2. Open any Story and click on the arrow to open the `Content Browser`
3.  The slug should be displayed with an ellipsis `...` at the end if it is too big.

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- This is a small fix for the ticket [STR-942](https://storyblok.atlassian.net/browse/STR-942) in storyfront. This PR prevent the slug to have linebreaks or scroll bars when the slugs are too long.