### PR TITLE
refactor(tabs): padding update

### DIFF
--- a/src/components/Tabs/tabs.scss
+++ b/src/components/Tabs/tabs.scss
@@ -7,6 +7,9 @@
 }
 
 .sb-tab-edit-button {
+  position: absolute;
+  right: -20px;
+  top: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -17,6 +20,7 @@
   cursor: pointer;
   opacity: 0;
   transform: none;
+  transform: translateY(-50%);
   fill: currentColor;
 }
 
@@ -25,7 +29,8 @@
   z-index: 0;
   display: flex;
   align-items: center;
-  padding: 14px 15px;
+  margin-right: 25px;
+  padding: 14px 2px;
   color: $sb-dark-blue-50;
   font-family: $primary-font-family;
   font-size: $font-14;
@@ -55,7 +60,7 @@
   }
 
   &--editable {
-    padding: 9px 0 9px 24px;
+    padding: 9px 2px;
 
     &:hover,
     &:focus {
@@ -66,16 +71,11 @@
   }
 
   &--has-icon {
-    padding: 9px 14px 9px 10px;
+    padding: 9px 0;
 
     span {
       margin-left: 5px;
     }
-  }
-
-  &--disabled {
-    cursor: not-allowed;
-    opacity: 0.5;
   }
 }
 
@@ -113,6 +113,7 @@
 
   &--container {
     .sb-tab--is-active {
+      padding: 8px;
       border: 1px solid $light-gray;
       border-radius: 5px 5px 0 0;
       border-bottom: 0;
@@ -132,6 +133,8 @@
     }
 
     .sb-tab--is-active {
+      padding-left: 8px;
+
       &::after {
         left: 0;
         top: 0;

--- a/src/components/Tabs/tabs.scss
+++ b/src/components/Tabs/tabs.scss
@@ -41,42 +41,42 @@
   &:hover {
     color: $primary-text-color;
   }
+}
 
-  // modifiers
-  &--is-active {
-    z-index: 3;
-    color: $primary-text-color;
-    font-weight: $font-weight-medium;
+.sb-tab--is-active {
+  z-index: 3;
+  color: $primary-text-color;
+  font-weight: $font-weight-medium;
 
-    &::after {
-      content: '';
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      height: 3px;
-      background-color: $sb-green;
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 3px;
+    background-color: $sb-green;
+  }
+}
+
+.sb-tab--editable {
+  padding: 9px 2px;
+
+  &:hover,
+  &:focus {
+    .sb-tab-edit-button {
+      opacity: 1;
     }
   }
+}
 
-  &--editable {
-    padding: 9px 2px;
+.sb-tab--has-icon {
+  padding: 9px 4px 9px 2px;
+}
 
-    &:hover,
-    &:focus {
-      .sb-tab-edit-button {
-        opacity: 1;
-      }
-    }
-  }
-
-  &--has-icon {
-    padding: 9px 0;
-
-    span {
-      margin-left: 5px;
-    }
-  }
+.sb-tab--disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .sb-tabs {
@@ -96,51 +96,49 @@
     height: 1px;
     background-color: $light;
   }
+}
 
-  // elements
-  &__add-button {
-    @include base--icon-hover;
+.sb-tabs__add-button {
+  @include base--icon-hover;
 
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    vertical-align: bottom;
-    margin-left: -12px;
-    background-color: transparent;
-    border: 0;
-    cursor: pointer;
-  }
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: bottom;
+  margin-left: -12px;
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+}
 
-  &--container {
-    .sb-tab--is-active {
-      padding: 8px;
-      border: 1px solid $light-gray;
-      border-radius: 5px 5px 0 0;
-      border-bottom: 0;
-
-      &::after {
-        background-color: $white;
-      }
-    }
-  }
-
-  // modifiers
-  &--vertical {
-    flex-direction: column;
+.sb-tabs--container {
+  .sb-tab--is-active {
+    padding: 8px;
+    border: 1px solid $light-gray;
+    border-radius: 5px 5px 0 0;
+    border-bottom: 0;
 
     &::after {
-      display: none;
+      background-color: $white;
     }
+  }
+}
 
-    .sb-tab--is-active {
-      padding-left: 8px;
+.sb-tabs--vertical {
+  flex-direction: column;
 
-      &::after {
-        left: 0;
-        top: 0;
-        width: 3px;
-        height: 100%;
-      }
+  &::after {
+    display: none;
+  }
+
+  .sb-tab--is-active {
+    padding-left: 8px;
+
+    &::after {
+      left: 0;
+      top: 0;
+      width: 3px;
+      height: 100%;
     }
   }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: -

Nikola requested to change the padding in the DS to the following:
![image](https://user-images.githubusercontent.com/11278408/167392429-2757c158-7545-4d1e-aa78-2c991407c12b.png)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
It's good to test inside the storyfront. There will be a second PR in the storyfront to fix all the tabs to be the same and aligned well:

1. `cd storyblok-design-system && git checkout fix/sb-tabs-padding`
2. Then on the localhost navigate the application and check if everything looks correct where tabs are used
3. You can also compare https://storyblok-design-system-git-fix-sb-tabs-padding-storyblok-com.vercel.app/ and https://blok.ink/

https://user-images.githubusercontent.com/11278408/167393508-c9c4ed2e-3f0f-4fef-8c17-aaa8b948ce02.mov


## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-  Less padding left and right on sb tabs
- 
- 

## Other information
