### PR TITLE
bugfix(INT-439): slideover title overlap icon

### DIFF
--- a/src/components/Slideover/Slideover.stories.js
+++ b/src/components/Slideover/Slideover.stories.js
@@ -34,7 +34,7 @@ const SlideoverTemplate = (args) => ({
         @hide="show = false"
         :orientation="orientation">
 
-        <SbModalHeader title="Title" align="left" />
+        <SbModalHeader :title="title" align="left" />
 
         <SbModalContent style="flex: 1;">
           <p>Storyblok helps your team to tell your story and...</p>
@@ -52,8 +52,13 @@ const SlideoverTemplate = (args) => ({
 export default {
   title: 'Design System/Components/SbSlideover',
   component: SbSlideover,
+  parameters: {
+    docs: { inlineStories: false, iframeHeight: 500 },
+    layout: 'fullscreen',
+  },
   args: {
     orientation: 'right',
+    title: 'Title',
   },
   argTypes: {
     orientation: {

--- a/src/components/Slideover/slideover.scss
+++ b/src/components/Slideover/slideover.scss
@@ -41,4 +41,8 @@
   .sb-modal-footer {
     margin-bottom: -20px;
   }
+
+  .sb-modal-header__title {
+    padding-right: 30px;
+  }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
This PR is required so that the sbSlideover title does not overlap the close icon.

## Pull request type

Jira Link: [INT-439 - [DS] - In SbSlideover the title and X to close overlap](https://storyblok.atlassian.net/browse/INT-439)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Go in:
https://storyblok-design-system-dgyoiptsl-storyblok-com.vercel.app/?path=/story/design-system-components-sbslideover--default
Set a new big title.

