### PR TITLE
task(int-452): Remove icon right in sbMenuButton and add color in icon the button

### DIFF
--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -303,7 +303,7 @@ export const Sizes = (args) => ({
   components: { SbButton },
   props: Object.keys(args),
   template: `<div>
-    <SbButton label="Small" size="small" :variant="variant" :icon="icon"  />
+    <SbButton label="Small" size="small" :variant="variant" :icon="icon" />
     <SbButton label="Default" :variant="variant" :icon="icon" />
     <SbButton label="Large" size="large" :variant="variant" :icon="icon" />
   </div>`,

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -2,6 +2,10 @@ import SbButton from './index'
 
 import { availablePositions as availableTooltipPositions } from '../Tooltip/lib'
 import { availableButtonsTypes } from './lib'
+import { availableColors } from '../../utils'
+import LIB_ICONS from '../../lib/internal-icons'
+
+const availableIcons = Object.keys(LIB_ICONS)
 
 const ButtonTemplate = (args) => ({
   components: { SbButton },
@@ -101,21 +105,24 @@ export default {
       name: 'iconRight',
       description: 'Icon on the right',
       control: {
-        type: 'text',
+        type: 'select',
+        options: availableIcons,
       },
     },
     iconColor: {
       name: 'iconColor',
       description: 'Icon color',
       control: {
-        type: 'text',
+        type: 'select',
+        options: availableColors,
       },
     },
     icon: {
       name: 'icon',
       description: 'Icon before label (default on the left)',
       control: {
-        type: 'text',
+        type: 'select',
+        options: availableIcons,
       },
     },
     isFullWidth: {

--- a/src/components/Button/Button.stories.js
+++ b/src/components/Button/Button.stories.js
@@ -19,6 +19,7 @@ const ButtonTemplate = (args) => ({
         :variant="variant"
         :is-disabled="isDisabled"
         :icon="icon"
+        :icon-color="iconColor"
         :label="label"
         :size="size"
         :type="type"
@@ -70,14 +71,15 @@ export default {
     isFullWidth: false,
     isRounded: false,
     icon: null,
-    iconDescription: null,
-    iconRight: null,
+    iconDescription: '',
+    iconRight: '',
     hasIconOnly: false,
     label: 'Default',
     size: null,
     variant: 'primary',
     tooltipPosition: 'bottom',
     type: null,
+    iconColor: '',
   },
   argTypes: {
     isDisabled: {
@@ -98,6 +100,13 @@ export default {
     iconRight: {
       name: 'iconRight',
       description: 'Icon on the right',
+      control: {
+        type: 'text',
+      },
+    },
+    iconColor: {
+      name: 'iconColor',
+      description: 'Icon color',
       control: {
         type: 'text',
       },
@@ -190,6 +199,7 @@ export const Default = (args) => ({
       :is-loading="isLoading"
       :is-disabled="isDisabled"
       :icon="icon"
+      :icon-color="iconColor"
       :icon-right="iconRight"
       :has-icon-only="hasIconOnly"
       :label="label"
@@ -197,6 +207,7 @@ export const Default = (args) => ({
       :variant="variant"
       :tooltip-position="tooltipPosition"
       :type="type"
+  
     />
   `,
 })
@@ -292,7 +303,7 @@ export const Sizes = (args) => ({
   components: { SbButton },
   props: Object.keys(args),
   template: `<div>
-    <SbButton label="Small" size="small" :variant="variant" :icon="icon" />
+    <SbButton label="Small" size="small" :variant="variant" :icon="icon"  />
     <SbButton label="Default" :variant="variant" :icon="icon" />
     <SbButton label="Large" size="large" :variant="variant" :icon="icon" />
   </div>`,
@@ -345,6 +356,7 @@ export const JustIcons = (args) => ({
       variant="primary"
       :size="size"
       :icon="icon"
+      :icon-color="iconColor"
       :is-loading="isLoading"
       :is-disabled="isDisabled"
       :type="type"
@@ -355,6 +367,7 @@ export const JustIcons = (args) => ({
       variant="secondary"
       :size="size"
       :icon="icon"
+      :icon-color="iconColor"
       :is-loading="isLoading"
       :is-disabled="isDisabled"
       :type="type"
@@ -365,6 +378,7 @@ export const JustIcons = (args) => ({
       variant="tertiary"
       :size="size"
       :icon="icon"
+      :icon-color="iconColor"
       :is-loading="isLoading"
       :is-disabled="isDisabled"
       :icon-description="iconDescription"
@@ -432,6 +446,7 @@ export const LoadingButton = (args) => ({
       :size="size"
       :variant="variant"
       :type="type"
+      :icon-color="iconColor"
     />`,
 })
 

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -32,6 +32,10 @@ const SbButton = {
       type: String,
       default: null,
     },
+    iconColor: {
+      type: String,
+      default: null,
+    },
     iconSize: {
       type: String,
       default: 'normal',
@@ -74,11 +78,12 @@ const SbButton = {
   render(h) {
     const useTooltip = this.hasIconOnly && this.iconDescription
 
-    const renderIcon = (icon) => {
+    const renderIcon = (icon, color) => {
       return h(SbIcon, {
         props: {
           size: this.iconSize,
           name: icon,
+          color: color,
         },
       })
     }
@@ -153,9 +158,9 @@ const SbButton = {
     }
 
     const content = [
-      this.icon && renderIcon(this.icon),
+      this.icon && renderIcon(this.icon, this.iconColor),
       !this.hasIconOnly && renderLabel(),
-      this.iconRight && renderIcon(this.iconRight),
+      this.iconRight && renderIcon(this.iconRight, this.iconColor),
     ]
 
     if (this.isLoading) {

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -83,7 +83,7 @@ const SbButton = {
         props: {
           size: this.iconSize,
           name: icon,
-          color: color,
+          color,
         },
       })
     }

--- a/src/components/Menu/Menu.stories.js
+++ b/src/components/Menu/Menu.stories.js
@@ -288,7 +288,6 @@ export const WithIconLeft = (args) => ({
     ref="contentButton"
     icon="plus"
     label="Combo"
-    :variant="variant"
     size="small"
     :has-icon-right="hasIconRight"
   />

--- a/src/components/Menu/Menu.stories.js
+++ b/src/components/Menu/Menu.stories.js
@@ -23,7 +23,7 @@ export default {
   },
   args: {
     value: true,
-    hasIconRight: true,
+    iconRight: 'chevron-down',
   },
   argTypes: {
     value: {
@@ -42,11 +42,11 @@ export default {
       },
       default: true,
     },
-    hasIconRight: {
-      name: 'hasIconRight',
+    iconRight: {
+      name: 'IconRight',
       description: `When the arrow down icon located at the right side of SbMenuButton is not needed for SbMenuButton, set this parameter to false.`,
       control: {
-        type: 'boolean',
+        type: 'string',
       },
       default: true,
     },
@@ -66,7 +66,7 @@ export const Default = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton label="Combo button" :has-icon-right="hasIconRight"/>
+        <SbMenuButton label="Combo button"/>
 
         <SbMenuList placement="bottom-start">
           <SbMenuGroup title="Actions">
@@ -98,7 +98,7 @@ export const WithSeparators = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton label="Combo button" :has-icon-right="hasIconRight"/>
+        <SbMenuButton label="Combo button" />
 
         <SbMenuList placement="bottom-start">
           <SbMenuItem> Option 1 </SbMenuItem>
@@ -131,7 +131,7 @@ export const WithIcons = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton label="Combo button" :has-icon-right="hasIconRight"/>
+        <SbMenuButton label="Combo button" />
 
         <SbMenuList placement="bottom-start">
           <SbMenuItem icon="calendar"> Option 1 </SbMenuItem>
@@ -223,7 +223,7 @@ export const WithLinksOnMenuItem = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton label="Combo button" :has-icon-right="hasIconRight"/>
+        <SbMenuButton label="Combo button" />
 
         <SbMenuList placement="bottom-start">
           <SbMenuGroup title="Links">
@@ -256,7 +256,7 @@ export const WithoutIconRight = (args) => ({
   template: `
   <div>
   <SbMenu :value="value">
-    <SbMenuButton label="Combo button" ref="contentButton" :has-icon-right="hasIconRight" />
+    <SbMenuButton label="Combo button" ref="contentButton" :icon-right="iconRight" />
 
     <SbMenuList placement="bottom-start" :reference="$refs.contentButton">
       <SbMenuItem> Option 1 </SbMenuItem>
@@ -268,7 +268,7 @@ export const WithoutIconRight = (args) => ({
 })
 
 WithoutIconRight.args = {
-  hasIconRight: false,
+  iconRight: null,
 }
 
 export const WithIconLeft = (args) => ({
@@ -289,7 +289,7 @@ export const WithIconLeft = (args) => ({
     icon="plus"
     label="Combo"
     size="small"
-    :has-icon-right="hasIconRight"
+    :icon-right="iconRight" 
   />
 
     <SbMenuList placement="bottom-start" :reference="$refs.contentButton">
@@ -302,5 +302,5 @@ export const WithIconLeft = (args) => ({
 })
 
 WithIconLeft.args = {
-  hasIconRight: false,
+  iconRight: null,
 }

--- a/src/components/Menu/Menu.stories.js
+++ b/src/components/Menu/Menu.stories.js
@@ -243,7 +243,7 @@ export const WithLinksOnMenuItem = (args) => ({
   `,
 })
 
-export const WithoutItemRight = (args) => ({
+export const WithoutIconRight = (args) => ({
   props: Object.keys(args),
   components: {
     SbMenu,

--- a/src/components/Menu/Menu.stories.js
+++ b/src/components/Menu/Menu.stories.js
@@ -9,6 +9,9 @@ import {
 
 import SbButton from '../Button'
 import SbGroupButton from '../GroupButton'
+import LIB_ICONS from '../../lib/internal-icons'
+
+const availableIcons = Object.keys(LIB_ICONS)
 
 export default {
   title: 'Design System/Components/SbMenu',
@@ -24,6 +27,7 @@ export default {
   args: {
     value: true,
     iconRight: 'chevron-down',
+    icon: null,
   },
   argTypes: {
     value: {
@@ -46,7 +50,17 @@ export default {
       name: 'IconRight',
       description: `When the arrow down icon located at the right side of SbMenuButton is not needed for SbMenuButton, set this parameter to false.`,
       control: {
-        type: 'string',
+        type: 'select',
+        options: availableIcons,
+      },
+      default: true,
+    },
+    icon: {
+      name: 'Icon',
+      description: `When the arrow down icon located at the left side of SbMenuButton is not needed for SbMenuButton, set this parameter to false.`,
+      control: {
+        type: 'select',
+        options: availableIcons,
       },
       default: true,
     },
@@ -66,7 +80,7 @@ export const Default = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton label="Combo button"/>
+        <SbMenuButton label="Combo button" :icon-right="iconRight" :icon="icon"/>
 
         <SbMenuList placement="bottom-start">
           <SbMenuGroup title="Actions">
@@ -98,7 +112,7 @@ export const WithSeparators = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton label="Combo button" />
+        <SbMenuButton label="Combo button" :icon-right="iconRight" :icon="icon"/>
 
         <SbMenuList placement="bottom-start">
           <SbMenuItem> Option 1 </SbMenuItem>
@@ -131,7 +145,7 @@ export const WithIcons = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton label="Combo button" />
+        <SbMenuButton label="Combo button" :icon-right="iconRight" :icon="icon"/>
 
         <SbMenuList placement="bottom-start">
           <SbMenuItem icon="calendar"> Option 1 </SbMenuItem>
@@ -160,7 +174,7 @@ export const ButtonWithJustIcon = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton has-icon-only is-rounded/>
+        <SbMenuButton has-icon-only is-rounded :icon-right="iconRight" :icon="icon"/>
 
         <SbMenuList placement="bottom-start">
           <SbMenuItem icon="calendar"> Option 1 </SbMenuItem>
@@ -223,7 +237,7 @@ export const WithLinksOnMenuItem = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton label="Combo button" />
+        <SbMenuButton label="Combo button" :icon-right="iconRight" :icon="icon"/>
 
         <SbMenuList placement="bottom-start">
           <SbMenuGroup title="Links">
@@ -256,7 +270,7 @@ export const WithoutIconRight = (args) => ({
   template: `
   <div>
   <SbMenu :value="value">
-    <SbMenuButton label="Combo button" ref="contentButton" :icon-right="iconRight" />
+    <SbMenuButton label="Combo button" ref="contentButton" :icon-right="iconRight" :icon="icon" />
 
     <SbMenuList placement="bottom-start" :reference="$refs.contentButton">
       <SbMenuItem> Option 1 </SbMenuItem>
@@ -286,7 +300,7 @@ export const WithIconLeft = (args) => ({
   <SbMenu :value="value">
   <SbMenuButton
     ref="contentButton"
-    icon="plus"
+    :icon="icon"
     label="Combo"
     size="small"
     :icon-right="iconRight" 
@@ -303,4 +317,5 @@ export const WithIconLeft = (args) => ({
 
 WithIconLeft.args = {
   iconRight: null,
+  icon: 'plus',
 }

--- a/src/components/Menu/Menu.stories.js
+++ b/src/components/Menu/Menu.stories.js
@@ -267,6 +267,41 @@ export const WithoutIconRight = (args) => ({
   `,
 })
 
-WithoutItemRight.args = {
+WithoutIconRight.args = {
+  hasIconRight: false,
+}
+
+export const WithIconLeft = (args) => ({
+  props: Object.keys(args),
+  components: {
+    SbMenu,
+    SbMenuButton,
+    SbMenuList,
+    SbMenuItem,
+    SbMenuGroup,
+    SbMenuSeparator,
+  },
+  template: `
+  <div>
+  <SbMenu :value="value">
+  <SbMenuButton
+    ref="contentButton"
+    icon="plus"
+    label="Combo"
+    :variant="variant"
+    size="small"
+    :has-icon-right="hasIconRight"
+  />
+
+    <SbMenuList placement="bottom-start" :reference="$refs.contentButton">
+      <SbMenuItem> Option 1 </SbMenuItem>
+      <SbMenuItem> Option 2 </SbMenuItem>
+    </SbMenuList>
+  </SbMenu>
+</div>
+  `,
+})
+
+WithIconLeft.args = {
   hasIconRight: false,
 }

--- a/src/components/Menu/Menu.stories.js
+++ b/src/components/Menu/Menu.stories.js
@@ -44,7 +44,7 @@ export default {
     },
     hasIconRight: {
       name: 'hasIconRight',
-      description: `When the down arrow icon which is located to the right of SbMenuButton is not needed for SbMenuButton, set this parameter to false.`,
+      description: `When the arrow down icon located at the right side of SbMenuButton is not needed for SbMenuButton, set this parameter to false.`,
       control: {
         type: 'boolean',
       },

--- a/src/components/Menu/Menu.stories.js
+++ b/src/components/Menu/Menu.stories.js
@@ -256,7 +256,7 @@ export const WithoutItemRight = (args) => ({
   template: `
   <div>
   <SbMenu :value="value">
-    <SbMenuButton label="Combo button" ref="contentButton" :has-icon-right="false" />
+    <SbMenuButton label="Combo button" ref="contentButton" :has-icon-right="hasIconRight" />
 
     <SbMenuList placement="bottom-start" :reference="$refs.contentButton">
       <SbMenuItem> Option 1 </SbMenuItem>
@@ -266,3 +266,7 @@ export const WithoutItemRight = (args) => ({
 </div>
   `,
 })
+
+WithoutItemRight.args = {
+  hasIconRight: false,
+}

--- a/src/components/Menu/Menu.stories.js
+++ b/src/components/Menu/Menu.stories.js
@@ -23,6 +23,7 @@ export default {
   },
   args: {
     value: true,
+    hasIconRight: true,
   },
   argTypes: {
     value: {
@@ -36,6 +37,14 @@ export default {
     focusWhenClose: {
       name: 'focusWhenClose',
       description: `When SbMenuList has more items than the screen's height, it could lead to an undesired scroll behavior. Set this property to false to prevent this.`,
+      control: {
+        type: 'boolean',
+      },
+      default: true,
+    },
+    hasIconRight: {
+      name: 'hasIconRight',
+      description: `When the down arrow icon which is located to the right of SbMenuButton is not needed for SbMenuButton, set this parameter to false.`,
       control: {
         type: 'boolean',
       },
@@ -57,7 +66,7 @@ export const Default = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton label="Combo button" />
+        <SbMenuButton label="Combo button" :has-icon-right="hasIconRight"/>
 
         <SbMenuList placement="bottom-start">
           <SbMenuGroup title="Actions">
@@ -89,7 +98,7 @@ export const WithSeparators = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton label="Combo button" />
+        <SbMenuButton label="Combo button" :has-icon-right="hasIconRight"/>
 
         <SbMenuList placement="bottom-start">
           <SbMenuItem> Option 1 </SbMenuItem>
@@ -122,7 +131,7 @@ export const WithIcons = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton label="Combo button" />
+        <SbMenuButton label="Combo button" :has-icon-right="hasIconRight"/>
 
         <SbMenuList placement="bottom-start">
           <SbMenuItem icon="calendar"> Option 1 </SbMenuItem>
@@ -151,7 +160,7 @@ export const ButtonWithJustIcon = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton has-icon-only is-rounded />
+        <SbMenuButton has-icon-only is-rounded/>
 
         <SbMenuList placement="bottom-start">
           <SbMenuItem icon="calendar"> Option 1 </SbMenuItem>
@@ -214,7 +223,7 @@ export const WithLinksOnMenuItem = (args) => ({
   template: `
     <div>
       <SbMenu :value="value">
-        <SbMenuButton label="Combo button" />
+        <SbMenuButton label="Combo button" :has-icon-right="hasIconRight"/>
 
         <SbMenuList placement="bottom-start">
           <SbMenuGroup title="Links">
@@ -231,5 +240,29 @@ export const WithLinksOnMenuItem = (args) => ({
         </SbMenuList>
       </SbMenu>
     </div>
+  `,
+})
+
+export const WithoutItemRight = (args) => ({
+  props: Object.keys(args),
+  components: {
+    SbMenu,
+    SbMenuButton,
+    SbMenuList,
+    SbMenuItem,
+    SbMenuGroup,
+    SbMenuSeparator,
+  },
+  template: `
+  <div>
+  <SbMenu :value="value">
+    <SbMenuButton label="Combo button" ref="contentButton" :has-icon-right="false" />
+
+    <SbMenuList placement="bottom-start" :reference="$refs.contentButton">
+      <SbMenuItem> Option 1 </SbMenuItem>
+      <SbMenuItem> Option 2 </SbMenuItem>
+    </SbMenuList>
+  </SbMenu>
+</div>
   `,
 })

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -419,9 +419,9 @@ const SbMenuButton = {
 
     isBorderless: Boolean,
 
-    hasIconRight: {
-      type: Boolean,
-      default: true,
+    iconRight: {
+      type: String,
+      default: 'chevron-down',
     },
 
     iconColor: {
@@ -523,7 +523,7 @@ const SbMenuButton = {
         },
         props: {
           iconColor: this.iconColor,
-          iconRight: this.hasIconRight ? 'chevron-down' : null,
+          iconRight: this.iconRight,
           label: this.label,
           isRounded: this.isRounded,
           variant: this.variant,

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -418,6 +418,16 @@ const SbMenuButton = {
     },
 
     isBorderless: Boolean,
+
+    hasIconRight: {
+      type: Boolean,
+      default: true,
+    },
+
+    iconColor: {
+      type: String,
+      default: null,
+    },
   },
 
   computed: {
@@ -486,6 +496,7 @@ const SbMenuButton = {
           isRounded: this.isRounded,
           hasIconOnly: true,
           icon: this.iconName || 'menu-vertical',
+          iconColor: this.iconColor,
           variant: this.variant,
           size: this.size,
           iconSize: this.iconSize,
@@ -511,7 +522,8 @@ const SbMenuButton = {
           'aria-expanded': isOpen ? 'true' : null,
         },
         props: {
-          iconRight: 'chevron-down',
+          iconColor: this.iconColor,
+          iconRight: this.hasIconRight ? 'chevron-down' : null,
           label: this.label,
           isRounded: this.isRounded,
           variant: this.variant,

--- a/src/components/Menu/menu.scss
+++ b/src/components/Menu/menu.scss
@@ -86,6 +86,12 @@
   }
 }
 
+.sb-menu-button {
+  &:focus {
+    outline: none;
+  }
+}
+
 .sb-menu-button-borderless {
   border: 0;
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
New parameters in the SbMenuButton:

- **hasIconRight**: Allows the user to use the component without the right arrow icon.
- **iconColor**: Change icon color

New parameters in SbMenu:

- **iconColor**: Change icon color

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
SbMenuButton, to test the component without the right arrow icon, go to:
https://storyblok-design-system-git-feat-int-452-r-9c57ac-storyblok-com.vercel.app/?path=/story/design-system-components-sbmenu--without-item-right

SbButton, to test the component with another icon color, go to and set a new color in iconColor: 
https://storyblok-design-system-git-feat-int-452-r-9c57ac-storyblok-com.vercel.app/?path=/story/design-system-components-sbbutton--just-icons
