### PR TITLE
bugfix(work-393): update `deselectRow` function to remove the correct row

### DIFF
--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -183,11 +183,10 @@ const SbDataTable = {
      * @param {Object} row
      */
     deselectRow(row) {
-      const index = this.selectedRows.indexOf(row)
-
-      if (index > -1) {
-        this.selectedRows.splice(index, 1)
-      }
+      this.selectedRows = this.selectedRows.filter((selectedRow) => {
+        if (JSON.stringify(selectedRow) !== JSON.stringify(row))
+          return selectedRow
+      })
     },
 
     /**


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [WORK-393](https://storyblok.atlassian.net/browse/WORK-393)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix

## How to test this PR
Please, check on the PR in the V2 repo, you can see the task and the videos with the problem and test in v2 preview.

Check if the deselect function is working on the `DataTable` only possible on multiple selection mode

## What is the new behavior?

- The same, it's a refactor on the function to deselectRows.

## Other information
