### PR TITLE
bugfix(INT-439): slideover title overlap icon

### DIFF
--- a/src/components/Slideover/slideover.scss
+++ b/src/components/Slideover/slideover.scss
@@ -44,5 +44,6 @@
 
   .sb-modal-header__title {
     padding-right: 30px;
+    word-break: break-all;
   }
 }

--- a/src/components/Slideover/slideover.scss
+++ b/src/components/Slideover/slideover.scss
@@ -30,7 +30,7 @@
 
     position: absolute;
     right: 20px;
-    top: 23px;
+    top: 20px;
     z-index: 2;
     background-color: transparent;
     border: 0;
@@ -43,7 +43,8 @@
   }
 
   .sb-modal-header__title {
-    padding-right: 30px;
-    word-break: break-all;
+    word-break: break-word; 
+    width: calc(100% - 36px);
+    line-height: 36px; 
   }
 }

--- a/src/components/Slideover/slideover.scss
+++ b/src/components/Slideover/slideover.scss
@@ -43,8 +43,8 @@
   }
 
   .sb-modal-header__title {
-    word-break: break-word; 
     width: calc(100% - 36px);
-    line-height: 36px; 
+    line-height: 30px;
+    word-break: break-word;
   }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
This PR is required so that the sbSlideover title does not overlap the close icon.

## Pull request type

Jira Link: [INT-439 - [DS] - In SbSlideover the title and X to close overlap](https://storyblok.atlassian.net/browse/INT-439)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Go in:
https://storyblok-design-system-dgyoiptsl-storyblok-com.vercel.app/?path=/story/design-system-components-sbslideover--default
Set a new big title.

