### PR TITLE
fix(work-354): fix tag label when text is too big without spaces

### DIFF
--- a/src/components/Tag/tag.scss
+++ b/src/components/Tag/tag.scss
@@ -19,7 +19,10 @@
   border-radius: 5px;
 
   &__label {
+    display: flex;
     flex: 1;
+    gap: 5px;
+    align-items: center;
     overflow: auto;
     line-height: 1.4em;
     text-overflow: ellipsis;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [WORK-354](https://storyblok.atlassian.net/browse/WORK-354)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?


<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fix tag label display when text is too large and has no spaces

## Other information
