### PR TITLE
fix(work-397): improve SbSelect to return a valid object for recently…

### DIFF
--- a/src/components/Select/Select.stories.js
+++ b/src/components/Select/Select.stories.js
@@ -30,6 +30,14 @@ const SelectTemplate = (args) => ({
     },
   },
 
+  methods: {
+    handleOptionCreated(value) {
+      const newValue = { value, label: value }
+      this.options.push(newValue)
+      this.internalValue.push(value)
+    },
+  },
+
   template: `
     <SbSelect
       :label="label"
@@ -47,8 +55,8 @@ const SelectTemplate = (args) => ({
       :show-caption="showCaption"
       v-model="internalValue"
       style="max-width: 300px"
-    />
-  `,
+      @option-created="handleOptionCreated"
+    />`,
 })
 
 export const defaultSelectOptionsData = [

--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -30,11 +30,11 @@
             size="small"
             :name="tagLabel[itemLabel]"
           />
-          <span :title="getTagTitle(tagLabel)">
-            <span v-if="showCaption">
+          <span class="sb-select-inner__tag" :title="getTagTitle(tagLabel)">
+            <template v-if="showCaption">
               {{ tagLabel[itemLabel] }} ({{ tagLabel[itemCaption] }})
-            </span>
-            <span v-else>{{ tagLabel[itemLabel] }}</span>
+            </template>
+            <template v-else>{{ tagLabel[itemLabel] || tagLabel }}</template>
           </span>
         </template>
       </SbTag>
@@ -299,7 +299,13 @@ export default {
           return $v
         }
 
-        return this.options.find(($opt) => $opt[this.itemValue] === $v)
+        const option = this.options.find(($opt) => $opt[this.itemValue] === $v)
+
+        if (this.allowCreate && !option) {
+          return this.emitOption ? { [this.itemValue]: $v } : $v
+        }
+
+        return option
       })
     },
 
@@ -479,7 +485,7 @@ export default {
      * get the tag value based on emitOption property
      */
     getComputedTagValue(tag) {
-      return this.emitOption ? tag : tag[this.itemValue]
+      return this.emitOption ? tag : tag[this.itemValue] || tag
     },
 
     getSource(label) {
@@ -490,7 +496,7 @@ export default {
     },
 
     getTagTitle(tagLabel) {
-      const label = tagLabel[this.itemLabel]
+      const label = tagLabel[this.itemLabel] || tagLabel
 
       if (this.showCaption) {
         const caption = tagLabel[this.itemCaption]

--- a/src/components/Select/components/SelectList.vue
+++ b/src/components/Select/components/SelectList.vue
@@ -30,9 +30,10 @@
         @keydown.enter="handleOptionCreated(searchInput)"
         @click="handleOptionCreated(searchInput)"
       >
-        <span class="sb-select-list__create-label">Create tag</span> "{{
-          searchInput
-        }}"
+        <span class="sb-select-list__create-label">Create tag</span>
+        <span class="sb-select-list__create-value" :title="searchInput">
+          "{{ searchInput }}"
+        </span>
       </li>
       <li v-else-if="!hasOptions && !isLoading">
         <span class="sb-select-list__empty">{{ noDataText }}</span>

--- a/src/components/Select/select.scss
+++ b/src/components/Select/select.scss
@@ -127,6 +127,11 @@
     .sb-avatar__initials {
       font-size: 0.7em;
     }
+
+    .sb-select-inner__tag {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 
   // elements
@@ -290,6 +295,8 @@
 
   &__item-name,
   &__create {
+    gap: 5px;
+    overflow: hidden;
     min-height: 17px;
     color: $sb-dark-blue;
   }
@@ -300,8 +307,14 @@
   }
 
   &__create-label {
-    margin-right: 5px;
     color: $sb-green;
+  }
+
+  &__create-value {
+    flex: 1;
+    overflow: hidden;
+    line-height: 1.5rem;
+    text-overflow: ellipsis;
   }
 
   &__empty {

--- a/src/components/Tag/tag.scss
+++ b/src/components/Tag/tag.scss
@@ -23,7 +23,7 @@
     flex: 1;
     gap: 5px;
     align-items: center;
-    overflow: auto;
+    overflow: hidden;
     line-height: 1.4em;
     text-overflow: ellipsis;
   }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [WORK-397](https://storyblok.atlassian.net/browse/WORK-397)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
The scenarios can be found on the ticket.

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- When using `BaseSelect` with `allowCreate` prop set as `true` the values previously created won't have their labels missing temporarily.

- When `allowCreate` option is enabled, the labels of the current value were temporarily "disappearing". Now, when retrieving the valid objects to represent them, a check on the `allowCreate` option is made, and then, a valid object is created with the proper label.

## Other information
