### PR TITLE
bugfix(INT-443): SbSelect with allow create update

### DIFF
--- a/src/components/Select/Select.stories.js
+++ b/src/components/Select/Select.stories.js
@@ -40,6 +40,7 @@ const SelectTemplate = (args) => ({
       :use-avatars="useAvatars"
       :inline="inline"
       :no-data-text="noDataText"
+      :no-data-text-tag="noDataTextTag"
       :allow-create="allowCreate"
       :is-loading="isLoading"
       :loading-label="loadingLabel"
@@ -246,6 +247,7 @@ AllowCreate.args = {
   allowCreate: true,
   filterable: true,
   multiple: true,
+  noDataTextTag: 'Start typing to add new tag.',
 }
 
 export const WithIcon = SelectTemplate.bind({})

--- a/src/components/Select/Select.stories.js
+++ b/src/components/Select/Select.stories.js
@@ -144,6 +144,7 @@ export default {
     useAvatars: false,
     inline: false,
     noDataText: 'Sorry, no result found.',
+    noDataTextTag: 'Start typing to add new tag.',
     allowCreate: false,
     clearable: false,
     isLoading: false,
@@ -211,6 +212,7 @@ export const LazySearch = (args) => ({
       :use-avatars="useAvatars"
       :inline="inline"
       :no-data-text="noDataText"
+      :no-data-text-tag="noDataTextTag"
       :allow-create="allowCreate"
       :is-loading="internalLoading"
       :loading-label="loadingLabel"
@@ -379,6 +381,7 @@ export const EmitOption = (args) => ({
           :use-avatars="useAvatars"
           :inline="inline"
           :no-data-text="noDataText"
+          :no-data-text-tag="noDataTextTag"
           :allow-create="allowCreate"
           :is-loading="isLoading"
           :loading-label="loadingLabel"
@@ -408,6 +411,7 @@ export const EmitOption = (args) => ({
         :use-avatars="useAvatars"
         :inline="inline"
         :no-data-text="noDataText"
+        :no-data-text-tag="noDataTextTag"
         :allow-create="allowCreate"
         :is-loading="isLoading"
         :loading-label="loadingLabel"
@@ -470,6 +474,7 @@ export const EmitSearch = (args) => ({
           :use-avatars="useAvatars"
           :inline="inline"
           :no-data-text="noDataText"
+          :no-data-text-tag="noDataTextTag"
           :allow-create="allowCreate"
           :is-loading="isLoading"
           :loading-label="loadingLabel"

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -59,6 +59,7 @@
       :multiple="multiple"
       :use-avatars="useAvatars"
       :no-data-text="noDataText"
+      :no-data-text-tag="noDataTextTag"
       :allow-create="allowCreate"
       :emit-option="emitOption"
       :show-caption="showCaption"
@@ -170,6 +171,10 @@ export default {
     noDataText: {
       type: String,
       default: 'Sorry, no result found.',
+    },
+    noDataTextTag: {
+      type: String,
+      default: 'Start typing to add new tag.',
     },
     errorMessage: {
       type: String,

--- a/src/components/Select/components/SelectList.vue
+++ b/src/components/Select/components/SelectList.vue
@@ -34,6 +34,9 @@
           searchInput
         }}"
       </li>
+      <li v-else-if="showTextStartingTagCreation">
+        <span class="sb-select-list__empty"> {{ noDataTextTag }} </span>
+      </li>
       <li v-else-if="!hasOptions && !isLoading">
         <span class="sb-select-list__empty">{{ noDataText }}</span>
       </li>
@@ -81,6 +84,10 @@ export default {
       default: 'value',
     },
     noDataText: {
+      type: String,
+      required: true,
+    },
+    noDataTextTag: {
       type: String,
       required: true,
     },
@@ -143,6 +150,15 @@ export default {
         this.allowCreate &&
         this.multiple &&
         this.searchInput
+      )
+    },
+
+    showTextStartingTagCreation() {
+      return (
+        (this.hasPartialMatch || !this.hasOptions) &&
+        !this.hasExactMatch &&
+        this.allowCreate &&
+        this.multiple
       )
     },
   },


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
To improve usability, in SbSelect when alowCreate with tags, when the combo is empty, we need to inform what the user should do and therefore instead of displaying the message "Sorry, no result found.", we now display "Start typing to add new tag."
## Pull request type

Jira Link: [INT-443 - SbSelect with allow create update](https://storyblok.atlassian.net/browse/INT-443)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

- Go in: https://storyblok-design-system-ogtt1ycae-storyblok-com.vercel.app/?path=/story/design-system-components-form-sbselect--allow-create
- Remove all options, leaving the array empty.
- Click on the combo and see if the new message is showing.
