### PR TITLE
bugfix(STR-1137): SbDropArea: Problems with drag and drop

### DIFF
--- a/src/components/DropArea/drop-area.scss
+++ b/src/components/DropArea/drop-area.scss
@@ -14,7 +14,7 @@
     background-color: rgba(19, 25, 45, 0.47);
     cursor: copy;
 
-    * {
+    div {
       pointer-events: none;
     }
 

--- a/src/components/DropArea/drop-area.scss
+++ b/src/components/DropArea/drop-area.scss
@@ -1,5 +1,6 @@
 .sb-drop-area {
   width: 100%;
+  min-height: 188px;
 
   &__over {
     position: fixed;
@@ -13,9 +14,15 @@
     background-color: rgba(19, 25, 45, 0.47);
     cursor: copy;
 
+    * {
+      pointer-events: none;
+    }
+
     .sb-drop-area__content {
+      width: 90%;
       background-color: $white;
       border-radius: 50%;
+      aspect-ratio: 1/1;
     }
 
     .sb-drop-area__icon {
@@ -32,9 +39,13 @@
     position: absolute;
     left: 50%;
     top: 50%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
     width: 100%;
-    height: 500px;
     max-width: 500px;
+    margin: auto;
     border: 1px solid transparent;
     transform: translate(-50%, -50%);
     transition: all 0.05s ease;
@@ -72,8 +83,6 @@
     justify-content: center;
     width: 104px;
     height: 104px;
-    margin: 0 auto;
-    margin-top: 159px;
     background-color: $white;
     border-radius: 50%;
     transition: $base-transition;

--- a/src/components/DropArea/drop-area.scss
+++ b/src/components/DropArea/drop-area.scss
@@ -14,14 +14,11 @@
     background-color: rgba(19, 25, 45, 0.47);
     cursor: copy;
 
-    div {
-      pointer-events: none;
-    }
-
     .sb-drop-area__content {
       width: 90%;
       background-color: $white;
       border-radius: 50%;
+      pointer-events: none;
       aspect-ratio: 1/1;
     }
 


### PR DESCRIPTION
This commit improves the `dragleave` event by adding the `pointer-events: none;` to all elements on mouseover.
It also fixes problems with the content size

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [STR-1137](https://storyblok.atlassian.net/browse/STR-1137)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Set a small window in the browser (width: 768 px)

1. Open the [sbDropArea page](https://storyblok-design-system-obaejwr4o-storyblok-com.vercel.app/?path=/story/design-system-components-sbdroparea--default)
2. From your file system explorer, select a file and drag it to the Asset area (don’t drop it)
4. Drag the Asset out of the window
5. The overlay should disappear.
6. Reload [SbDropArea page](https://storyblok-design-system-obaejwr4o-storyblok-com.vercel.app/?path=/story/design-system-components-sbdroparea--default)
7. Again, from your file system explorer, select a file and drag it to the Asset area, don’t drop it, and press the Escape key (Esc)
8. The overlay should disappear.

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- This PR improves the `dragleave` behavior of the SbDropArea and also enhances the CSS for smaller screens
