### PR TITLE
bugfix(int-459): remove icon in text field error

### DIFF
--- a/src/components/TextField/SbTextField.vue
+++ b/src/components/TextField/SbTextField.vue
@@ -76,7 +76,7 @@
         />
       </SbTooltip>
       <SbIcon
-        v-if="(iconRight || error) && type !== 'password'"
+        v-if="(iconRight || (error && iconRight)) && type !== 'password'"
         :name="iconRight"
         class="sb-textfield__icon sb-textfield__icon--right"
         :color="iconColor"

--- a/src/components/TextField/TextField.stories.js
+++ b/src/components/TextField/TextField.stories.js
@@ -99,6 +99,20 @@ export const Default = (args) => ({
         error
       />
       <SbTextField
+      style="margin-bottom: 20px;"
+      :id="id"
+      :name="name"
+      label="With error but no icon"
+      :disabled="disabled"
+      :required="required"
+      :placeholder="placeholder"
+      iconRight=""
+      native-value="Some text with error but no icon"
+      v-model="internalValue"
+      :errorMessage="errorMessage"
+      error
+    />
+      <SbTextField
         style="margin-bottom: 20px;"
         :id="id"
         :name="name"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
In this PR I add a new condition to display the icon only when the "iconRight" property is filled, so we avoid the error in the console "Error: <svg> attribute viewBox: Unexpected end of the attribute. Expected number, ""." when the error type is active.
## Pull request type

Jira Link: [INT-459 - Sbtextfield: Unexpected end of the attribute. Expected number, "".](https://storyblok.atlassian.net/browse/INT-459)

<!-- Please try to limit your pull request to one type, and submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Go in:
Open the console and check that the above error message is not displayed.
