### PR TITLE
Bugfix: keep the span tag when button has loading state

### DIFF
--- a/src/components/Button/SbButton.vue
+++ b/src/components/Button/SbButton.vue
@@ -8,12 +8,10 @@
     v-on="localListeners"
     @click="handleClick"
   >
-    <SbLoading
-      v-if="isLoading"
-      type="spinner"
-      size="small"
-      :color="loadingColor"
-    />
+    <template v-if="isLoading">
+      <span class="sb-button__label">{{ label }}</span>
+      <SbLoading type="spinner" size="small" :color="loadingColor" />
+    </template>
     <template v-else>
       <SbIcon v-if="icon" :size="iconSize" :name="icon" :color="iconColor" />
       <span v-if="!hasIconOnly" class="sb-button__label"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

You can checkout your DS branch to this PR's branch and test the loading buttons of Storyblok app locally. Here are some examples:

https://user-images.githubusercontent.com/26799272/181383743-f9e74f59-5d19-464f-8bde-ade4f15e49b4.mov

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Keeping the span element which makes the button to the keep the correct height
- 
- 

## Other information
