### PR TITLE
feature(int-512): datetime field date entry

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
   transformIgnorePatterns: [
     // ignores popper lib
     'node_modules/(?!(@popperjs)/)'
-  ]
+  ],
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.js'],
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dayjs": "^1.11.3",
     "portal-vue": "^2.1.7",
     "throttle-debounce": "^4.0.1",
+    "v-mask": "^2.3.0",
     "vue-fragment": "^1.6.0"
   },
   "peerDependencies": {

--- a/setup-jest.js
+++ b/setup-jest.js
@@ -1,0 +1,6 @@
+import { createLocalVue } from '@vue/test-utils'
+import VueMask from 'v-mask'
+
+global.localVue = createLocalVue()
+
+global.localVue.use(VueMask)

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -2,6 +2,7 @@
 
 // teal
 $sb-green: #00b3b0;
+$sb-green-100: #40bebb;
 $sb-green-75: #40c6c4;
 $sb-green-50: #7fd9d7;
 $sb-green-25: #d9f4f3;

--- a/src/components/Accordion/__tests__/Accordion.spec.js
+++ b/src/components/Accordion/__tests__/Accordion.spec.js
@@ -1,8 +1,12 @@
-import { mount } from '@vue/test-utils'
+import { mount, createLocalVue } from '@vue/test-utils'
 
 import Accordion from '..'
 
 import SbTextField from '../../TextField'
+
+import VueMask from 'v-mask'
+const localVue = createLocalVue();
+localVue.use(VueMask);
 
 const factory = (propsData) => {
   return mount(Accordion, {
@@ -13,6 +17,7 @@ const factory = (propsData) => {
     stubs: {
       SbTextField,
     },
+    localVue,
   })
 }
 

--- a/src/components/Accordion/__tests__/Accordion.spec.js
+++ b/src/components/Accordion/__tests__/Accordion.spec.js
@@ -1,12 +1,10 @@
-import { mount, createLocalVue } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 
 import Accordion from '..'
 
 import SbTextField from '../../TextField'
 
-import VueMask from 'v-mask'
-const localVue = createLocalVue()
-localVue.use(VueMask)
+const localVue = global.localVue
 
 const factory = (propsData) => {
   return mount(Accordion, {

--- a/src/components/Accordion/__tests__/Accordion.spec.js
+++ b/src/components/Accordion/__tests__/Accordion.spec.js
@@ -5,8 +5,8 @@ import Accordion from '..'
 import SbTextField from '../../TextField'
 
 import VueMask from 'v-mask'
-const localVue = createLocalVue();
-localVue.use(VueMask);
+const localVue = createLocalVue()
+localVue.use(VueMask)
 
 const factory = (propsData) => {
   return mount(Accordion, {

--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -8,7 +8,7 @@ const Template = (args) => ({
   props: Object.keys(args),
 
   data: () => ({
-    internalDatetimeValue: dayjs(),
+    internalDatetimeValue: dayjs().format('YYYY-MM-DD HH:mm'),
   }),
 
   template: `
@@ -18,6 +18,7 @@ const Template = (args) => ({
       :time-zone="timeZone"
       :tz-tooltip="tzTooltip"
       :type="type"
+      :readonly="readonly"
       v-model="internalDatetimeValue"
       style="width: 29.4rem"
     />
@@ -35,6 +36,7 @@ export default {
     isoDate: false,
     timeZone: 'America/Detroit',
     tzTooltip: null,
+    readonly: true,
   },
   argTypes: {
     timeZone: {
@@ -158,6 +160,23 @@ WithTzOffset.parameters = {
     description: {
       story:
         'Use `timeZone` property to describe the user timezone. It is possible to use an optional property called `tzTooltip` to display a tooltip message for `timeZone` information.',
+    },
+  },
+}
+
+export const NoReadOnly = Template.bind({})
+
+NoReadOnly.args = {
+  readonly: false,
+  placeholder: 'YYYY-MM-DD',
+  type: 'date',
+}
+
+NoReadOnly.parameters = {
+  docs: {
+    description: {
+      story:
+        'Use `readonly=false` property to enable manual data entry in Datepicker',
     },
   },
 }

--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -18,7 +18,6 @@ const Template = (args) => ({
       :time-zone="timeZone"
       :tz-tooltip="tzTooltip"
       :type="type"
-      :readonly="readonly"
       v-model="internalDatetimeValue"
       style="width: 29.4rem"
       :min-date="minDate"
@@ -39,7 +38,6 @@ export default {
     isoDate: false,
     timeZone: 'America/Detroit',
     tzTooltip: null,
-    readonly: true,
     minDate: null,
     maxDate: null,
     disabledPast: false,
@@ -166,23 +164,6 @@ WithTzOffset.parameters = {
     description: {
       story:
         'Use `timeZone` property to describe the user timezone. It is possible to use an optional property called `tzTooltip` to display a tooltip message for `timeZone` information.',
-    },
-  },
-}
-
-export const NoReadOnly = Template.bind({})
-
-NoReadOnly.args = {
-  readonly: false,
-  placeholder: 'YYYY-MM-DD',
-  type: 'date',
-}
-
-NoReadOnly.parameters = {
-  docs: {
-    description: {
-      story:
-        'Use `readonly=false` property to enable manual data entry in Datepicker',
     },
   },
 }

--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -199,7 +199,7 @@ MinMaxDate.parameters = {
   docs: {
     description: {
       story:
-        'Use `readonly=false` property to enable manual data entry in Datepicker',
+        'Add the `minDate` attribute to establish a minimum selectable date and add the `maxDate` attribute to establish a maximum selectable date.',
     },
   },
 }

--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -37,9 +37,9 @@ export default {
     disabled: false,
     isoDate: false,
     timeZone: 'America/Detroit',
-    tzTooltip: null,
-    minDate: null,
-    maxDate: null,
+    tzTooltip: '',
+    minDate: '',
+    maxDate: '',
     disabledPast: false,
   },
   argTypes: {
@@ -108,6 +108,33 @@ export default {
         type: 'boolean',
       },
     },
+    minDate: {
+      name: 'minDate',
+      description:
+        'If set, Datepicker will disable dates before the date entered in minDate',
+      defaultValue: '',
+      control: {
+        type: 'text',
+      },
+    },
+    maxDate: {
+      name: 'maxDate',
+      description:
+        'If set, Datepicker will disable dates after the date entered in maxDate',
+      defaultValue: '',
+      control: {
+        type: 'text',
+      },
+    },
+    disabledPast: {
+      name: 'disabledPast',
+      description:
+        'If set to true, Datepicker will disable dates before the current date',
+      defaultValue: false,
+      control: {
+        type: 'boolean',
+      },
+    }
   },
 }
 

--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs'
 import { SbDatepicker } from '.'
 import { datepickerOptions } from './utils'
 
@@ -7,7 +8,7 @@ const Template = (args) => ({
   props: Object.keys(args),
 
   data: () => ({
-    internalDatetimeValue: '2017-09-09 00:00',
+    internalDatetimeValue: dayjs(),
   }),
 
   template: `

--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -21,6 +21,8 @@ const Template = (args) => ({
       :readonly="readonly"
       v-model="internalDatetimeValue"
       style="width: 29.4rem"
+      :min-date="minDate"
+      :max-date="maxDate"
     />
   `,
 })
@@ -37,6 +39,8 @@ export default {
     timeZone: 'America/Detroit',
     tzTooltip: null,
     readonly: true,
+    minDate: null,
+    maxDate: null
   },
   argTypes: {
     timeZone: {
@@ -170,9 +174,28 @@ NoReadOnly.args = {
   readonly: false,
   placeholder: 'YYYY-MM-DD',
   type: 'date',
+  minDate:  dayjs().subtract(3, 'day'),
+  maxDate:   dayjs().add(3, 'day'),
 }
 
 NoReadOnly.parameters = {
+  docs: {
+    description: {
+      story:
+        'Use `readonly=false` property to enable manual data entry in Datepicker',
+    },
+  },
+}
+
+export const MinMaxDate = Template.bind({})
+
+MinMaxDate.args = {
+  placeholder: 'YYYY-MM-DD',
+  minDate:  dayjs().subtract(3, 'day'),
+  maxDate:   dayjs().add(3, 'day'),
+}
+
+MinMaxDate.parameters = {
   docs: {
     description: {
       story:

--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -215,7 +215,7 @@ DisabledDatePast.parameters = {
   docs: {
     description: {
       story:
-        'Add the `minDate` attribute to establish a minimum selectable date and add the `maxDate` attribute to establish a maximum selectable date.',
+        'Add the `disabled-past` attribute to disabled select dates in past.',
     },
   },
 }

--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -134,7 +134,7 @@ export default {
       control: {
         type: 'boolean',
       },
-    }
+    },
   },
 }
 

--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -23,6 +23,7 @@ const Template = (args) => ({
       style="width: 29.4rem"
       :min-date="minDate"
       :max-date="maxDate"
+      :disabled-past="disabledPast"
     />
   `,
 })
@@ -40,7 +41,8 @@ export default {
     tzTooltip: null,
     readonly: true,
     minDate: null,
-    maxDate: null
+    maxDate: null,
+    disabledPast: false
   },
   argTypes: {
     timeZone: {
@@ -174,8 +176,6 @@ NoReadOnly.args = {
   readonly: false,
   placeholder: 'YYYY-MM-DD',
   type: 'date',
-  minDate:  dayjs().subtract(3, 'day'),
-  maxDate:   dayjs().add(3, 'day'),
 }
 
 NoReadOnly.parameters = {
@@ -191,8 +191,8 @@ export const MinMaxDate = Template.bind({})
 
 MinMaxDate.args = {
   placeholder: 'YYYY-MM-DD',
-  minDate:  dayjs().subtract(3, 'day'),
-  maxDate:   dayjs().add(3, 'day'),
+  minDate:  dayjs().subtract(3, 'day').format('YYYY-MM-DD'),
+  maxDate:   dayjs().add(3, 'day').format('YYYY-MM-DD'),
 }
 
 MinMaxDate.parameters = {
@@ -203,3 +203,20 @@ MinMaxDate.parameters = {
     },
   },
 }
+
+export const DisabledDatePast = Template.bind({})
+
+DisabledDatePast.args = {
+  placeholder: 'YYYY-MM-DD',
+  disabledPast: true
+}
+
+DisabledDatePast.parameters = {
+  docs: {
+    description: {
+      story:
+        'Add the `minDate` attribute to establish a minimum selectable date and add the `maxDate` attribute to establish a maximum selectable date.',
+    },
+  },
+}
+

--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -42,7 +42,7 @@ export default {
     readonly: true,
     minDate: null,
     maxDate: null,
-    disabledPast: false
+    disabledPast: false,
   },
   argTypes: {
     timeZone: {
@@ -190,9 +190,8 @@ NoReadOnly.parameters = {
 export const MinMaxDate = Template.bind({})
 
 MinMaxDate.args = {
-  placeholder: 'YYYY-MM-DD',
-  minDate:  dayjs().subtract(3, 'day').format('YYYY-MM-DD'),
-  maxDate:   dayjs().add(3, 'day').format('YYYY-MM-DD'),
+  minDate: dayjs().subtract(3, 'day').format('YYYY-MM-DD'),
+  maxDate: dayjs().add(3, 'day').format('YYYY-MM-DD'),
 }
 
 MinMaxDate.parameters = {
@@ -207,8 +206,7 @@ MinMaxDate.parameters = {
 export const DisabledDatePast = Template.bind({})
 
 DisabledDatePast.args = {
-  placeholder: 'YYYY-MM-DD',
-  disabledPast: true
+  disabledPast: true,
 }
 
 DisabledDatePast.parameters = {
@@ -219,4 +217,3 @@ DisabledDatePast.parameters = {
     },
   },
 }
-

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -8,7 +8,9 @@
     <div class="sb-datepicker__input">
       <SbTextField
         ref="input"
-        readonly
+        v-model="internalValue"
+        :mask="internalMask"
+        :readonly="readonly"
         clearable
         type="text"
         icon-left="calendar"
@@ -17,6 +19,7 @@
         :value="internalValueFormatted"
         @click.native="handleInputClick"
         @clear="handleClear"
+        v-on:keyup.enter="handleDoneAction"
       />
 
       <template v-if="isShowTzOffset">
@@ -121,6 +124,11 @@ export default {
   props: {
     disabled: Boolean,
 
+    readonly: {
+      type: Boolean,
+      default: true,
+    },
+
     isoDate: {
       type: Boolean,
       default: false,
@@ -168,10 +176,18 @@ export default {
       date: 'YYYY-MM-DD',
       datetime: 'YYYY-MM-DD HH:mm',
     },
+    MASKS: {
+      date: '####-##-##',
+      datetime: '####-##-## ##:##',
+    },
     hitClear: false,
   }),
 
   computed: {
+    internalMask() {
+      return this.MASKS[this.type]
+    },
+
     internalFormat() {
       return this.FORMATS[this.type]
     },
@@ -237,6 +253,11 @@ export default {
     value: {
       handler: 'syncInternalValue',
       immediate: true,
+    },
+    internalValue() {
+      if (this.internalValue.length >= 4) {
+        this.internalDate =this.internalValue
+      }
     },
   },
 

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -310,7 +310,7 @@ export default {
         this.internalFormat,
         true
       ).isValid()
-      if (!isValid || (this.hasDayDisabled && this.dateValidation())) {
+      if (!isValid || (this.hasDayDisabled && this.isDateDisabled())) {
         this.handleClear(this.internalValue)
         return
       }
@@ -427,7 +427,7 @@ export default {
       if (this.internalValue === 'Invalid Date') this.internalValue = ''
     },
 
-    dateValidation() {
+    isDateDisabled() {
       let valid = false
       if (this.disabledPast && dayjs().isAfter(this.internalValue, 'day')) {
         valid = true

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -76,7 +76,7 @@
           class="sb-datepicker__action-button sb-datepicker__action-button--primary"
           @click="handleDoneAction"
         >
-          Done
+          Apply
         </button>
       </div>
     </SbPopover>

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -304,8 +304,12 @@ export default {
 
     handleDoneAction() {
       let utcTime
-      
-      const isValid = dayjs(this.internalValue, this.internalFormat, true).isValid()
+
+      const isValid = dayjs(
+        this.internalValue,
+        this.internalFormat,
+        true
+      ).isValid()
       if (!isValid || (this.hasDayDisabled && this.dateValidation())) {
         this.handleClear(this.internalValue)
         return
@@ -437,8 +441,8 @@ export default {
         dayjs(this.internalValue).isSameOrAfter(this.maxDate, 'day')
       ) {
         valid = true
-      } 
-      
+      }
+
       return valid
     },
 

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -19,7 +19,7 @@
         :value="internalValueFormatted"
         @click.native="handleInputClick"
         @clear="handleClear"
-        v-on:keyup.enter="handleDoneAction"
+        @keyup.enter="handleDoneAction"
       />
 
       <template v-if="isShowTzOffset">
@@ -256,7 +256,7 @@ export default {
     },
     internalValue() {
       if (this.internalValue.length >= 4) {
-        this.internalDate =this.internalValue
+        this.internalDate = this.internalValue
       }
     },
   },

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -86,6 +86,7 @@
 <script>
 import dayjs from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
 import utc from 'dayjs/plugin/utc'
 
 import { ClickOutside, Tooltip } from '../../directives'
@@ -102,6 +103,7 @@ import SbDatepickerYears from './components/DatepickerYears'
 import { datepickerOptions, INTERNAL_VIEWS } from './utils'
 
 dayjs.extend(timezone)
+dayjs.extend(customParseFormat)
 dayjs.extend(utc)
 
 export default {
@@ -302,8 +304,9 @@ export default {
 
     handleDoneAction() {
       let utcTime
-
-      if (this.hasDayDisabled && this.dateValidation()) {
+      
+      const isValid = dayjs(this.internalValue, this.internalFormat, true).isValid()
+      if (!isValid || (this.hasDayDisabled && this.dateValidation())) {
         this.handleClear(this.internalValue)
         return
       }
@@ -434,8 +437,8 @@ export default {
         dayjs(this.internalValue).isSameOrAfter(this.maxDate, 'day')
       ) {
         valid = true
-      }
-
+      } 
+      
       return valid
     },
 

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -10,10 +10,8 @@
         ref="input"
         v-model="internalValue"
         :mask="internalMask"
-        :readonly="readonly"
-        clearable
         type="text"
-        icon-left="calendar"
+        icon-right="calendar"
         :disabled="disabled"
         :placeholder="placeholder"
         :value="internalValueFormatted"
@@ -126,11 +124,6 @@ export default {
 
   props: {
     disabled: Boolean,
-
-    readonly: {
-      type: Boolean,
-      default: true,
-    },
 
     isoDate: {
       type: Boolean,

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -62,6 +62,7 @@
         :internal-date="internalDate"
         :min-date="minDate"
         :max-date="maxDate"
+        :disabled-past="disabledPast"
         @input="handleComponentsInput"
       />
 
@@ -175,6 +176,11 @@ export default {
     maxDate: {
       type: String,
       default: null,
+    },
+
+    disabledPast: {
+      type: Boolean,
+      default: false,
     },
 
   },

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -15,7 +15,7 @@
         :disabled="disabled"
         :placeholder="placeholder"
         :value="internalValueFormatted"
-        @click.native="handleInputClick"
+        @icon-click="handleInputClick"
         @clear="handleClear"
         @keyup.enter="handleDoneAction"
       />
@@ -255,7 +255,7 @@ export default {
     },
 
     tzOffsetValue() {
-      if (!this.timeZone || !this.internalValue) {
+      if (!this.timeZone || !this.internalValue || (this.internalValue.length <= 4) ) {
         return ''
       }
 
@@ -417,22 +417,22 @@ export default {
     },
 
     dateValidation() {
-      let disabled = false
+      let valid = false
       if (this.disabledPast && dayjs().isAfter(this.internalValue, 'day')) {
-        disabled = true
+        valid = true
       } else if (
         this.minDate &&
         dayjs(this.internalValue).isSameOrBefore(this.minDate, 'day')
       ) {
-        disabled = true
+        valid = true
       } else if (
         this.maxDate &&
         dayjs(this.internalValue).isSameOrAfter(this.maxDate, 'day')
       ) {
-        disabled = true
+        valid = true
       }
 
-      return disabled
+      return valid
     },
 
     $_wrapClose(e) {

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -60,6 +60,8 @@
         :is="isComponentView"
         :value="internalValue"
         :internal-date="internalDate"
+        :min-date="minDate"
+        :max-date="maxDate"
         @input="handleComponentsInput"
       />
 
@@ -164,6 +166,17 @@ export default {
       type: String,
       default: '',
     },
+
+    minDate: {
+      type: String,
+      default: null,
+    },
+
+    maxDate: {
+      type: String,
+      default: null,
+    },
+
   },
 
   data: () => ({

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -255,7 +255,11 @@ export default {
     },
 
     tzOffsetValue() {
-      if (!this.timeZone || !this.internalValue || (this.internalValue.length <= 4) ) {
+      if (
+        !this.timeZone ||
+        !this.internalValue ||
+        this.internalValue.length <= 4
+      ) {
         return ''
       }
 

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -182,7 +182,6 @@ export default {
       type: Boolean,
       default: false,
     },
-
   },
 
   data: () => ({
@@ -203,6 +202,10 @@ export default {
   }),
 
   computed: {
+    hasDayDisabled() {
+      return this.maxDate || this.minDate || this.disabledPast
+    },
+
     internalMask() {
       return this.MASKS[this.type]
     },
@@ -302,6 +305,11 @@ export default {
 
     handleDoneAction() {
       let utcTime
+
+      if (this.hasDayDisabled && this.dateValidation()) {
+        this.handleClear(this.internalValue)
+        return
+      }
 
       if (!this.tzOffset) {
         utcTime = dayjs
@@ -413,6 +421,25 @@ export default {
       }
 
       if (this.internalValue === 'Invalid Date') this.internalValue = ''
+    },
+
+    dateValidation() {
+      let disabled = false
+      if (this.disabledPast && dayjs().isAfter(this.internalValue, 'day')) {
+        disabled = true
+      } else if (
+        this.minDate &&
+        dayjs(this.internalValue).isSameOrBefore(this.minDate, 'day')
+      ) {
+        disabled = true
+      } else if (
+        this.maxDate &&
+        dayjs(this.internalValue).isSameOrAfter(this.maxDate, 'day')
+      ) {
+        disabled = true
+      }
+
+      return disabled
     },
 
     $_wrapClose(e) {

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -387,7 +387,7 @@ export default {
         return
       }
 
-      this.isOverlayVisible = true
+      this.isOverlayVisible = !this.isOverlayVisible
       this.internalVisualization = INTERNAL_VIEWS.CALENDAR
     },
 

--- a/src/components/Datepicker/__tests__/Datepicker.spec.js
+++ b/src/components/Datepicker/__tests__/Datepicker.spec.js
@@ -1,14 +1,11 @@
-import { mount, createLocalVue } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 import dayjs from 'dayjs'
 
 import SbDatepicker from '../Datepicker.vue'
 import SbDatepickerData, { WithTzOffset } from '../Datepicker.stories'
 
 import { INTERNAL_VIEWS } from '../utils'
-
-import VueMask from 'v-mask'
-const localVue = createLocalVue()
-localVue.use(VueMask)
+const localVue = global.localVue
 
 describe('SbDatepicker component', () => {
   const factory = (propsData) => {

--- a/src/components/Datepicker/__tests__/Datepicker.spec.js
+++ b/src/components/Datepicker/__tests__/Datepicker.spec.js
@@ -7,14 +7,14 @@ import SbDatepickerData, { WithTzOffset } from '../Datepicker.stories'
 import { INTERNAL_VIEWS } from '../utils'
 
 import VueMask from 'v-mask'
-const localVue = createLocalVue();
-localVue.use(VueMask);
+const localVue = createLocalVue()
+localVue.use(VueMask)
 
 describe('SbDatepicker component', () => {
   const factory = (propsData) => {
     return mount(SbDatepicker, {
       propsData,
-      localVue
+      localVue,
     })
   }
   const { placeholder } = SbDatepickerData.args

--- a/src/components/Datepicker/__tests__/Datepicker.spec.js
+++ b/src/components/Datepicker/__tests__/Datepicker.spec.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { mount, createLocalVue } from '@vue/test-utils'
 import dayjs from 'dayjs'
 
 import SbDatepicker from '../Datepicker.vue'
@@ -6,10 +6,15 @@ import SbDatepickerData, { WithTzOffset } from '../Datepicker.stories'
 
 import { INTERNAL_VIEWS } from '../utils'
 
+import VueMask from 'v-mask'
+const localVue = createLocalVue();
+localVue.use(VueMask);
+
 describe('SbDatepicker component', () => {
   const factory = (propsData) => {
     return mount(SbDatepicker, {
       propsData,
+      localVue
     })
   }
   const { placeholder } = SbDatepickerData.args

--- a/src/components/Datepicker/__tests__/DatepickerDays.spec.js
+++ b/src/components/Datepicker/__tests__/DatepickerDays.spec.js
@@ -29,15 +29,15 @@ describe('SbDatepickerDays component', () => {
     })
 
     it('Should include the `sb-datepicker-days item--disabled` class when maxDate or minDate is passed', async () => {
-      const minDate =   dayjs().add(3, 'day').format()
-      const maxDate =  dayjs().subtract(3, 'day').format()
+      const minDate = dayjs().add(3, 'day').format()
+      const maxDate = dayjs().subtract(3, 'day').format()
       await wrapper.setProps({ minDate, maxDate })
 
       expect(wrapper.find('.sb-datepicker-days__item--disabled')).toBeTruthy()
     })
 
     it('Should include the `sb-datepicker-days__item--disabled` class when disabledPast is true', async () => {
-      const disabledPast =  true
+      const disabledPast = true
       await wrapper.setProps({ disabledPast })
 
       expect(wrapper.find('.sb-datepicker-days__item--disabled')).toBeTruthy()

--- a/src/components/Datepicker/__tests__/DatepickerDays.spec.js
+++ b/src/components/Datepicker/__tests__/DatepickerDays.spec.js
@@ -14,4 +14,33 @@ describe('SbDatepickerDays component', () => {
       expect(wrapper.emitted().input[0].length).toBe(1)
     })
   })
+
+  describe('Test class date', () => {
+    it('Should include the `sb-datepicker-days__item--current` class in the current day', async () => {
+      const internalDate = dayjs().add(3, 'day').format()
+      await wrapper.setProps({ internalDate })
+      expect(wrapper.find('.sb-datepicker-days__item--current')).toBeTruthy()
+    })
+
+    it('Should include the `sb-datepicker-days__item--active` class in the active day', async () => {
+      const internalDate = dayjs().format()
+      await wrapper.setProps({ internalDate })
+      expect(wrapper.find('.sb-datepicker-days__item--active')).toBeTruthy()
+    })
+
+    it('Should include the `sb-datepicker-days item--disabled` class when maxDate or minDate is passed', async () => {
+      const minDate =   dayjs().add(3, 'day').format()
+      const maxDate =  dayjs().subtract(3, 'day').format()
+      await wrapper.setProps({ minDate, maxDate })
+
+      expect(wrapper.find('.sb-datepicker-days__item--disabled')).toBeTruthy()
+    })
+
+    it('Should include the `sb-datepicker-days__item--disabled` class when disabledPast is true', async () => {
+      const disabledPast =  true
+      await wrapper.setProps({ disabledPast })
+
+      expect(wrapper.find('.sb-datepicker-days__item--disabled')).toBeTruthy()
+    })
+  })
 })

--- a/src/components/Datepicker/components/DatepickerDays.vue
+++ b/src/components/Datepicker/components/DatepickerDays.vue
@@ -124,12 +124,12 @@ export default {
         disabled = true
       } else if (
         this.minDate &&
-        dayjs(dateValue).isSameOrBefore(this.minDate, 'day')
+        dayjs(dateValue).isBefore(this.minDate, 'day')
       ) {
         disabled = true
       } else if (
         this.maxDate &&
-        dayjs(dateValue).isSameOrAfter(this.maxDate, 'day')
+        dayjs(dateValue).isAfter(this.maxDate, 'day')
       ) {
         disabled = true
       }

--- a/src/components/Datepicker/components/DatepickerDays.vue
+++ b/src/components/Datepicker/components/DatepickerDays.vue
@@ -19,11 +19,6 @@
 
 <script>
 import dayjs from 'dayjs'
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
-
-dayjs.extend(isSameOrAfter)
-dayjs.extend(isSameOrBefore)
 
 export default {
   name: 'SbDatepickerDays',
@@ -66,7 +61,7 @@ export default {
           inMonth: false,
           checked: false,
           current: false,
-          disabled: this.setDisabledDay(dateValue),
+          disabled: this.isDisabledDay(dateValue),
         })
       }
 
@@ -79,7 +74,7 @@ export default {
           inMonth: true,
           checked: dayjs(this.value).isSame(dateValue, 'day'),
           current: dayjs().isSame(dateValue, 'day'),
-          disabled: this.setDisabledDay(dateValue),
+          disabled: this.isDisabledDay(dateValue),
         })
       }
 
@@ -93,7 +88,7 @@ export default {
           inMonth: false,
           checked: false,
           current: false,
-          disabled: this.setDisabledDay(dateValue),
+          disabled: this.isDisabledDay(dateValue),
         })
       }
 
@@ -118,7 +113,7 @@ export default {
       return _day === 0 ? 7 : _day
     },
 
-    setDisabledDay(dateValue) {
+    isDisabledDay(dateValue) {
       let disabled = false
       if (this.disabledPast && dayjs().isAfter(dateValue, 'day')) {
         disabled = true

--- a/src/components/Datepicker/components/DatepickerDays.vue
+++ b/src/components/Datepicker/components/DatepickerDays.vue
@@ -45,6 +45,10 @@ export default {
       type: String,
       default: null,
     },
+    disabledPast: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     days() {
@@ -115,7 +119,9 @@ export default {
     },
 
     setDisabledDay(dateValue) {
-      if (this.minDate && dayjs(dateValue).isSameOrBefore(this.minDate, 'day')) {
+      if (this.disabledPast && dayjs().isAfter(dateValue, 'day')) {
+        return true
+      } else if (this.minDate && dayjs(dateValue).isSameOrBefore(this.minDate, 'day')) {
         return true;
       } else if (this.maxDate && dayjs(dateValue).isSameOrAfter(this.maxDate, 'day')) {
         return true

--- a/src/components/Datepicker/components/DatepickerDays.vue
+++ b/src/components/Datepicker/components/DatepickerDays.vue
@@ -119,15 +119,16 @@ export default {
     },
 
     setDisabledDay(dateValue) {
+      let disabled = false;
       if (this.disabledPast && dayjs().isAfter(dateValue, 'day')) {
-        return true
+        disabled = true
       } else if (this.minDate && dayjs(dateValue).isSameOrBefore(this.minDate, 'day')) {
-        return true;
+        disabled = true
       } else if (this.maxDate && dayjs(dateValue).isSameOrAfter(this.maxDate, 'day')) {
-        return true
+        disabled = true
       }
 
-      return false
+      return disabled
 
     }
   },

--- a/src/components/Datepicker/components/DatepickerDays.vue
+++ b/src/components/Datepicker/components/DatepickerDays.vue
@@ -119,18 +119,23 @@ export default {
     },
 
     setDisabledDay(dateValue) {
-      let disabled = false;
+      let disabled = false
       if (this.disabledPast && dayjs().isAfter(dateValue, 'day')) {
         disabled = true
-      } else if (this.minDate && dayjs(dateValue).isSameOrBefore(this.minDate, 'day')) {
+      } else if (
+        this.minDate &&
+        dayjs(dateValue).isSameOrBefore(this.minDate, 'day')
+      ) {
         disabled = true
-      } else if (this.maxDate && dayjs(dateValue).isSameOrAfter(this.maxDate, 'day')) {
+      } else if (
+        this.maxDate &&
+        dayjs(dateValue).isSameOrAfter(this.maxDate, 'day')
+      ) {
         disabled = true
       }
 
       return disabled
-
-    }
+    },
   },
 }
 </script>

--- a/src/components/Datepicker/components/DatepickerDays.vue
+++ b/src/components/Datepicker/components/DatepickerDays.vue
@@ -7,6 +7,7 @@
       :class="{
         'sb-datepicker-days__item--inactive': !dayItem.inMonth,
         'sb-datepicker-days__item--active': dayItem.checked,
+        'sb-datepicker-days__item--current': dayItem.current,
       }"
       @click="($evt) => handleDayClick($evt, dayItem)"
     >
@@ -46,6 +47,7 @@ export default {
           date: dateValue,
           inMonth: false,
           checked: false,
+          current: false,
         })
       }
 
@@ -56,7 +58,8 @@ export default {
           label: i,
           date: dateValue,
           inMonth: true,
-          checked: dayjs(this.value).isSame(dateValue),
+          checked: dayjs(this.value).isSame(dateValue, 'day'),
+          current: dayjs().isSame(dateValue, 'day'),
         })
       }
 
@@ -69,6 +72,7 @@ export default {
           date: dateValue,
           inMonth: false,
           checked: false,
+          current: false,
         })
       }
 

--- a/src/components/Datepicker/components/DatepickerDays.vue
+++ b/src/components/Datepicker/components/DatepickerDays.vue
@@ -8,6 +8,7 @@
         'sb-datepicker-days__item--inactive': !dayItem.inMonth,
         'sb-datepicker-days__item--active': dayItem.checked,
         'sb-datepicker-days__item--current': dayItem.current,
+        'sb-datepicker-days__item--disabled': dayItem.disabled,
       }"
       @click="($evt) => handleDayClick($evt, dayItem)"
     >
@@ -18,6 +19,11 @@
 
 <script>
 import dayjs from 'dayjs'
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
+
+dayjs.extend(isSameOrAfter)
+dayjs.extend(isSameOrBefore)
 
 export default {
   name: 'SbDatepickerDays',
@@ -28,6 +34,14 @@ export default {
       default: null,
     },
     internalDate: {
+      type: String,
+      default: null,
+    },
+    minDate: {
+      type: String,
+      default: null,
+    },
+    maxDate: {
       type: String,
       default: null,
     },
@@ -48,6 +62,7 @@ export default {
           inMonth: false,
           checked: false,
           current: false,
+          disabled: this.setDisabledDay(dateValue),
         })
       }
 
@@ -60,6 +75,7 @@ export default {
           inMonth: true,
           checked: dayjs(this.value).isSame(dateValue, 'day'),
           current: dayjs().isSame(dateValue, 'day'),
+          disabled: this.setDisabledDay(dateValue),
         })
       }
 
@@ -73,6 +89,7 @@ export default {
           inMonth: false,
           checked: false,
           current: false,
+          disabled: this.setDisabledDay(dateValue),
         })
       }
 
@@ -81,6 +98,9 @@ export default {
   },
   methods: {
     handleDayClick($event, day) {
+      if (day.disabled) {
+        return
+      }
       $event.stopPropagation()
       this.$emit('input', day.date.format())
     },
@@ -93,6 +113,17 @@ export default {
       const _day = dayJsInstance.day()
       return _day === 0 ? 7 : _day
     },
+
+    setDisabledDay(dateValue) {
+      if (this.minDate && dayjs(dateValue).isSameOrBefore(this.minDate, 'day')) {
+        return true;
+      } else if (this.maxDate && dayjs(dateValue).isSameOrAfter(this.maxDate, 'day')) {
+        return true
+      }
+
+      return false
+
+    }
   },
 }
 </script>

--- a/src/components/Datepicker/datepicker.scss
+++ b/src/components/Datepicker/datepicker.scss
@@ -47,6 +47,10 @@
 
   &__input {
     position: relative;
+
+    .sb-textfield__icon {
+      cursor: pointer
+    }
   }
 
   &__timezone {
@@ -89,6 +93,9 @@
     &--primary {
       color: $color-primary;
     }
+
+
+
   }
 }
 

--- a/src/components/Datepicker/datepicker.scss
+++ b/src/components/Datepicker/datepicker.scss
@@ -73,12 +73,12 @@
 
   &__actions {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     background-color: $white;
   }
 
   &__action-button {
-    padding: 15px 20px;
+    padding: 15px 37.5px;
     color: $color-primary-dark;
     font-size: $font-14;
     font-weight: $font-weight-medium;
@@ -91,10 +91,9 @@
     }
 
     &--primary {
-      color: $color-primary;
+      color: white;
+      background-color: $color-primary;
     }
-
-
 
   }
 }

--- a/src/components/Datepicker/datepicker.scss
+++ b/src/components/Datepicker/datepicker.scss
@@ -9,6 +9,14 @@
     background-color: $sb-dark-blue-25;
   }
 
+  &--current {
+    background-color: $light-50;
+
+    &:hover {
+      background-color: $sb-green-25;
+    }
+  }
+
   &--active {
     font-size: $font-19;
     font-weight: $font-weight-medium;
@@ -76,7 +84,7 @@
 
 .sb-datepicker-header {
   z-index: 2;
-  background-color: $light;
+  background-color: $light-50;
 
   &__top {
     display: flex;
@@ -121,7 +129,7 @@
 .sb-datepicker-week {
   display: flex;
   padding-bottom: 10px;
-  background-color: $light;
+  background-color: $light-50;
 
   span {
     flex: 1;

--- a/src/components/Datepicker/datepicker.scss
+++ b/src/components/Datepicker/datepicker.scss
@@ -26,6 +26,16 @@
       background-color: $sb-green-25;
     }
   }
+
+  &--disabled {
+    color: $sb-dark-blue-50;
+    text-decoration: line-through;
+    cursor: no-drop;
+
+    &:hover {
+      background-color: white;
+    }
+  }
 }
 
 .sb-datepicker {

--- a/src/components/FormGroup/__tests__/FormGroup.spec.js
+++ b/src/components/FormGroup/__tests__/FormGroup.spec.js
@@ -5,8 +5,8 @@ import SbFormGroup from '..'
 import SbTextField from '../../TextField'
 
 import VueMask from 'v-mask'
-const localVue = createLocalVue();
-localVue.use(VueMask);
+const localVue = createLocalVue()
+localVue.use(VueMask)
 
 const factory = (propsData) => {
   return mount(SbFormGroup, {
@@ -17,7 +17,7 @@ const factory = (propsData) => {
     stubs: {
       SbTextField,
     },
-    localVue
+    localVue,
   })
 }
 

--- a/src/components/FormGroup/__tests__/FormGroup.spec.js
+++ b/src/components/FormGroup/__tests__/FormGroup.spec.js
@@ -1,8 +1,12 @@
-import { mount } from '@vue/test-utils'
+import { mount, createLocalVue } from '@vue/test-utils'
 
 import SbFormGroup from '..'
 
 import SbTextField from '../../TextField'
+
+import VueMask from 'v-mask'
+const localVue = createLocalVue();
+localVue.use(VueMask);
 
 const factory = (propsData) => {
   return mount(SbFormGroup, {
@@ -13,6 +17,7 @@ const factory = (propsData) => {
     stubs: {
       SbTextField,
     },
+    localVue
   })
 }
 

--- a/src/components/FormGroup/__tests__/FormGroup.spec.js
+++ b/src/components/FormGroup/__tests__/FormGroup.spec.js
@@ -1,12 +1,10 @@
-import { mount, createLocalVue } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 
 import SbFormGroup from '..'
 
 import SbTextField from '../../TextField'
 
-import VueMask from 'v-mask'
-const localVue = createLocalVue()
-localVue.use(VueMask)
+const localVue = global.localVue
 
 const factory = (propsData) => {
   return mount(SbFormGroup, {

--- a/src/components/FormItem/__tests__/FormItem.spec.js
+++ b/src/components/FormItem/__tests__/FormItem.spec.js
@@ -1,9 +1,13 @@
-import { mount } from '@vue/test-utils'
+import { mount, createLocalVue } from '@vue/test-utils'
 
 import SbFormItem from '..'
 
 import SbIcon from '../../Icon'
 import SbTextField from '../../TextField'
+
+import VueMask from 'v-mask'
+const localVue = createLocalVue();
+localVue.use(VueMask);
 
 const factory = (propsData) => {
   return mount(SbFormItem, {
@@ -14,6 +18,7 @@ const factory = (propsData) => {
     stubs: {
       SbTextField,
     },
+    localVue
   })
 }
 

--- a/src/components/FormItem/__tests__/FormItem.spec.js
+++ b/src/components/FormItem/__tests__/FormItem.spec.js
@@ -6,8 +6,8 @@ import SbIcon from '../../Icon'
 import SbTextField from '../../TextField'
 
 import VueMask from 'v-mask'
-const localVue = createLocalVue();
-localVue.use(VueMask);
+const localVue = createLocalVue()
+localVue.use(VueMask)
 
 const factory = (propsData) => {
   return mount(SbFormItem, {
@@ -18,7 +18,7 @@ const factory = (propsData) => {
     stubs: {
       SbTextField,
     },
-    localVue
+    localVue,
   })
 }
 

--- a/src/components/FormItem/__tests__/FormItem.spec.js
+++ b/src/components/FormItem/__tests__/FormItem.spec.js
@@ -1,13 +1,11 @@
-import { mount, createLocalVue } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 
 import SbFormItem from '..'
 
 import SbIcon from '../../Icon'
 import SbTextField from '../../TextField'
 
-import VueMask from 'v-mask'
-const localVue = createLocalVue()
-localVue.use(VueMask)
+const localVue = global.localVue
 
 const factory = (propsData) => {
   return mount(SbFormItem, {

--- a/src/components/TextField/SbTextField.vue
+++ b/src/components/TextField/SbTextField.vue
@@ -10,6 +10,7 @@
         :id="id"
         ref="textfield"
         v-model="computedValue"
+        v-mask="mask"
         v-bind="$attrs"
         class="sb-textfield__input"
         :type="internalType"
@@ -26,7 +27,6 @@
         @keydown="handleKeyDownInput"
         @keypress="handleKeyPressInput"
         @keyup="handleKeyUpInput"
-        v-mask="mask"
       />
 
       <textarea
@@ -163,8 +163,8 @@ export default {
     },
     mask: {
       type: String,
-      default: ''
-    }
+      default: '',
+    },
   },
 
   computed: {

--- a/src/components/TextField/SbTextField.vue
+++ b/src/components/TextField/SbTextField.vue
@@ -26,6 +26,7 @@
         @keydown="handleKeyDownInput"
         @keypress="handleKeyPressInput"
         @keyup="handleKeyUpInput"
+        v-mask="mask"
       />
 
       <textarea
@@ -160,6 +161,10 @@ export default {
       type: [String, Number, Boolean],
       default: '',
     },
+    mask: {
+      type: String,
+      default: ''
+    }
   },
 
   computed: {

--- a/src/components/TextField/TextField.stories.js
+++ b/src/components/TextField/TextField.stories.js
@@ -23,7 +23,7 @@ export default {
     suffix: '.com',
 
     maxlength: 60,
-    mask: '####-##-##'
+    mask: '####-##-##',
   },
 }
 
@@ -389,7 +389,7 @@ export const withMask = (args) => ({
 
 withMask.args = {
   placeholder: '####-##-##',
-  mask: '####-##-##'
+  mask: '####-##-##',
 }
 withMask.parameters = {
   docs: {

--- a/src/components/TextField/TextField.stories.js
+++ b/src/components/TextField/TextField.stories.js
@@ -23,6 +23,7 @@ export default {
     suffix: '.com',
 
     maxlength: 60,
+    mask: '####-##-##'
   },
 }
 
@@ -360,3 +361,41 @@ export const TextArea = (args) => ({
     </div>
   `,
 })
+
+export const withMask = (args) => ({
+  components: { SbTextField },
+  props: Object.keys(args),
+  data: () => ({
+    internalValue: '',
+  }),
+  template: `
+    <div style="max-width: 300px">
+      <SbTextField
+        style="margin-bottom: 20px;"
+        :id="id"
+        :name="name"
+        label="With mask"
+        :disabled="disabled"
+        :required="required"
+        :placeholder="placeholder"
+        :readonly="readonly"
+        native-value="Boris Spassky"
+        v-model="internalValue"
+        :mask="mask"
+      />
+    </div>
+  `,
+})
+
+withMask.args = {
+  placeholder: '####-##-##',
+  mask: '####-##-##'
+}
+withMask.parameters = {
+  docs: {
+    description: {
+      story:
+        'Use "#" for numbers (0-9), "A" for letter in any case (a-z,A-Z), "N" for number or letter (a-z,A-Z,0-9), "X" for any symbol and "?" for optional (next character)',
+    },
+  },
+}

--- a/src/components/TextField/__tests__/TextField.spec.js
+++ b/src/components/TextField/__tests__/TextField.spec.js
@@ -1,9 +1,14 @@
 import SbTextField from '..'
-import { mount } from '@vue/test-utils'
+import { mount, createLocalVue } from '@vue/test-utils'
+import VueMask from 'v-mask'
+const localVue = createLocalVue();
+localVue.use(VueMask);
+
 
 const factory = (propsData) => {
   return mount(SbTextField, {
     propsData,
+    localVue,
   })
 }
 

--- a/src/components/TextField/__tests__/TextField.spec.js
+++ b/src/components/TextField/__tests__/TextField.spec.js
@@ -1,8 +1,6 @@
 import SbTextField from '..'
-import { mount, createLocalVue } from '@vue/test-utils'
-import VueMask from 'v-mask'
-const localVue = createLocalVue()
-localVue.use(VueMask)
+import { mount } from '@vue/test-utils'
+const localVue = global.localVue
 
 const factory = (propsData) => {
   return mount(SbTextField, {

--- a/src/components/TextField/__tests__/TextField.spec.js
+++ b/src/components/TextField/__tests__/TextField.spec.js
@@ -1,9 +1,8 @@
 import SbTextField from '..'
 import { mount, createLocalVue } from '@vue/test-utils'
 import VueMask from 'v-mask'
-const localVue = createLocalVue();
-localVue.use(VueMask);
-
+const localVue = createLocalVue()
+localVue.use(VueMask)
 
 const factory = (propsData) => {
   return mount(SbTextField, {

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,6 @@ import createModalPlugin from './components/Modal/plugin/create-modal-plugin'
 // Prefered: as a plugin (directive + filter) + custom placeholders support
 import VueMask from 'v-mask'
 
-
 // Create module definition for Vue.use()
 const BlokInkPlugin = {
   installed: false,

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,10 @@ import { Tooltip } from './directives'
 // Import SbModal Plugin
 import createModalPlugin from './components/Modal/plugin/create-modal-plugin'
 
+// Prefered: as a plugin (directive + filter) + custom placeholders support
+import VueMask from 'v-mask'
+
+
 // Create module definition for Vue.use()
 const BlokInkPlugin = {
   installed: false,
@@ -27,6 +31,8 @@ const BlokInkPlugin = {
       // modal will be available in this.$sb.modal(options)
       modal: createModalPlugin(VueInstance),
     }
+
+    VueInstance.use(VueMask)
   },
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12330,14 +12330,7 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@^2.6.1:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
-
-node-fetch@^2.6.7:
+node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -16896,6 +16889,11 @@ uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+v-mask@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v-mask/-/v-mask-2.3.0.tgz#2329c352ce9997eb721d160cf3f0a8552c5c9e1c"
+  integrity sha512-ap7pTtCTvj25CqX4VYXqudCBd0+XvYyhiiLbzWQQR7AMQosJ2+DPu0a94P9stk0EGmGcmYxJaPkFkfjD8hquWQ==
 
 v8-compile-cache@^2.0.3:
   version "2.1.1"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
In this PR we added the features requested by Nikola, they are:

- Enable the input for the user to type the date respecting the format imposed by the mask.

- Open the calendar by clicking on the calendar icon.

- Remove the clearable icon and allow the user to manually remove the date with the backspace.

- Add a specific style for the current date.

- Change the style of footer buttons and also change the text "Done" to "Apply".

- Add the `disabledPast` prop to disable dates before the current date.

- Add the `minDate` so that the user can enter a minimum viable date.

- Add the `maxDate` so that the user can enter a maximum viable date.

To make the above adjustments possible I also changed the SbTextField and added a new story 'With Mask'.

## Pull request type

Jira Link: [INT-512 - DateTime field manual date entry](https://storyblok.atlassian.net/browse/INT-512)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Open the datepicker in blok.ink and verify that the styling and new props are working correctly.
Also check out the new 'With Mask' story from SbTextField.



## Other information
Any questions, I'm available!