### PR TITLE
refactor(int-512): remove v-mask globaly

### DIFF
--- a/src/components/TextField/SbTextField.vue
+++ b/src/components/TextField/SbTextField.vue
@@ -127,6 +127,7 @@
 
 <script>
 import SbIcon from '../Icon'
+import { VueMaskDirective } from 'v-mask'
 
 import TextFieldMixin from '../../mixins/textfield-mixin'
 import { Tooltip } from '../../directives'
@@ -136,6 +137,7 @@ export default {
 
   directives: {
     tooltip: Tooltip,
+    mask: VueMaskDirective,
   },
 
   components: { SbIcon },

--- a/src/main.js
+++ b/src/main.js
@@ -9,9 +9,6 @@ import { Tooltip } from './directives'
 // Import SbModal Plugin
 import createModalPlugin from './components/Modal/plugin/create-modal-plugin'
 
-// Prefered: as a plugin (directive + filter) + custom placeholders support
-import VueMask from 'v-mask'
-
 // Create module definition for Vue.use()
 const BlokInkPlugin = {
   installed: false,
@@ -30,8 +27,6 @@ const BlokInkPlugin = {
       // modal will be available in this.$sb.modal(options)
       modal: createModalPlugin(VueInstance),
     }
-
-    VueInstance.use(VueMask)
   },
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Removing the v-mask from the global vue and using it as a directive inside the SbTextfield component.

## Pull request type

Jira Link: [INT-512](https://storyblok.atlassian.net/browse/INT-512)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Check if the SbTextfield component mask is working properly.
