### PR TITLE
fix(str-1272): fix SbSelect to deal properly with created options when multiple

### DIFF
--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -364,7 +364,6 @@ export default {
      * @param {Array<String>|String} value
      */
     handleEmitValue(value) {
-      // doesn't close the list
       if (this.multiple) {
         const valueExists = this.options.find(
           (option) =>

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -380,6 +380,8 @@ export default {
           this.handleOptionCreated(value)
         }
 
+        this.searchInput = ''
+
         return
       }
 

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -366,9 +366,21 @@ export default {
     handleEmitValue(value) {
       // doesn't close the list
       if (this.multiple) {
-        this.searchInput = ''
-        const $value = this.processMultipleValue(value)
-        this.$emit('input', $value)
+        const valueExists = this.options.find(
+          (option) =>
+            option === value ||
+            option[this.itemValue] === value ||
+            option[this.itemLabel] === value
+        )
+
+        if (valueExists) {
+          const parsedValue = this.emitOption ? valueExists : value
+          const inputValue = this.processMultipleValue(parsedValue)
+          this.$emit('input', inputValue)
+        } else if (this.allowCreate) {
+          this.handleOptionCreated(value)
+        }
+
         return
       }
 
@@ -385,6 +397,9 @@ export default {
     handleOptionCreated(value) {
       this.searchInput = ''
       this.$emit('option-created', value)
+
+      if (this.multiple) return
+
       this.$_focusInner()
       this.hideList()
     },

--- a/src/components/Select/select.scss
+++ b/src/components/Select/select.scss
@@ -320,6 +320,7 @@
 
   &__empty {
     display: block;
+    padding-top: 13px;
     color: $sb-dark-blue-50;
     font-size: 1.3rem;
     text-align: center;


### PR DESCRIPTION
This PR fixes the behavior of `multiple` `SbSelect` with `allow-create` prop set to `true`.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [STR-1272](https://storyblok.atlassian.net/browse/STR-1272)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
The main steps can be found on the ticket.

**It's important to perform a regression tests on all `Multiple Select` scenarios within the application, to make sure everything is working as expected. These are the points:**

**⚠️  For QA (call me if any help is needed to go through the potential scenarios)**

_Base Select Occurrences_
<img width="851" alt="image" src="https://user-images.githubusercontent.com/4389464/186743716-4bf28a78-7a16-426a-a1de-babef1707a51.png">

_SbSelect occurrences_
<img width="769" alt="image" src="https://user-images.githubusercontent.com/4389464/186743857-0f12f9a8-6dc3-4163-9e74-10bfd75a7841.png">



## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- When the `SbSelect` is `multiple` and has `allow-create` set to `true`, the value will be properly created also when hitting `Enter` key.

## Other information
