### PR TITLE
fix(work-518): fix pagination number list padding

### DIFF
--- a/src/components/Pagination/pagination.scss
+++ b/src/components/Pagination/pagination.scss
@@ -147,4 +147,8 @@
       }
     }
   }
+
+  .sb-select-list__item {
+    padding: 10px 5px;
+  }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [WORK-518](https://storyblok.atlassian.net/browse/WORK-518)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
1. Access _Storyblok demo space_
2. Navigate to _Activities_
3. Check the page list on the top bottom
4. Make sure big numbers like 100 or 600 do not cut.
 
**This change will take effect no on _Activities_ page, but all lists with pagination with more than 100 pages available for selection.**

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Reduce the padding of the pagination list item to fit bigger numbers

## Other information
