### PR TITLE
Bugfix(int-588):  Error when filling minDate with the wrong format in documentation

### DIFF
--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -111,7 +111,7 @@ export default {
     minDate: {
       name: 'minDate',
       description:
-        'If set, Datepicker will disable dates before the date entered in minDate',
+        'If set, Datepicker will disable dates before the date entered in minDate. Expected format `YYYY-MM-DD`.',
       defaultValue: '',
       control: {
         type: 'text',
@@ -120,7 +120,7 @@ export default {
     maxDate: {
       name: 'maxDate',
       description:
-        'If set, Datepicker will disable dates after the date entered in maxDate',
+        'If set, Datepicker will disable dates after the date entered in maxDate. Expected format `YYYY-MM-DD`.',
       defaultValue: '',
       control: {
         type: 'text',
@@ -206,7 +206,7 @@ MinMaxDate.parameters = {
   docs: {
     description: {
       story:
-        'Add the `minDate` attribute to establish a minimum selectable date and add the `maxDate` attribute to establish a maximum selectable date.',
+        'Add the `minDate` attribute to establish a minimum selectable date and add the `maxDate` attribute to establish a maximum selectable date. Expected format `YYYY-MM-DD`.',
     },
   },
 }

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -89,8 +89,6 @@
 import dayjs from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
-import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 import utc from 'dayjs/plugin/utc'
 
 import { ClickOutside, Tooltip } from '../../directives'
@@ -108,8 +106,6 @@ import { datepickerOptions, INTERNAL_VIEWS } from './utils'
 
 dayjs.extend(timezone)
 dayjs.extend(customParseFormat)
-dayjs.extend(isSameOrBefore)
-dayjs.extend(isSameOrAfter)
 dayjs.extend(utc)
 
 export default {
@@ -448,15 +444,13 @@ export default {
 
     isMinDateDisabled() {
       return (
-        this.minDate &&
-        dayjs(this.internalValue).isSameOrBefore(this.minDate, 'day')
+        this.minDate && dayjs(this.internalValue).isBefore(this.minDate, 'day')
       )
     },
 
     isMaxDateDisabled() {
       return (
-        this.maxDate &&
-        dayjs(this.internalValue).isSameOrAfter(this.maxDate, 'day')
+        this.maxDate && dayjs(this.internalValue).isAfter(this.maxDate, 'day')
       )
     },
 

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -275,6 +275,30 @@ export default {
       if (this.tzOffset) return this.tzOffset.replace('GMT', '')
       return dayjs.tz(this.internalValue, this.timeZone).format('Z')
     },
+
+    isDateDisabledPast() {
+      return this.disabledPast && dayjs().isAfter(this.internalValue, 'day')
+    },
+
+    isMinDateDisabled() {
+      return (
+        this.minDate && dayjs(this.internalValue).isBefore(this.minDate, 'day')
+      )
+    },
+
+    isMaxDateDisabled() {
+      return (
+        this.maxDate && dayjs(this.internalValue).isAfter(this.maxDate, 'day')
+      )
+    },
+
+    isDateDisabled() {
+      return !!(
+        this.isDateDisabledPast ||
+        this.isMinDateDisabled ||
+        this.isMaxDateDisabled
+      )
+    },
   },
 
   watch: {
@@ -321,7 +345,7 @@ export default {
         this.internalFormat,
         true
       ).isValid()
-      if (!isValid || (this.hasDayDisabled && this.isDateDisabled())) {
+      if (!isValid || (this.hasDayDisabled && this.isDateDisabled)) {
         this.invalidDate = true
         return
       }
@@ -436,30 +460,6 @@ export default {
       }
 
       if (this.internalValue === 'Invalid Date') this.internalValue = ''
-    },
-
-    isDateDisabledPast() {
-      return this.disabledPast && dayjs().isAfter(this.internalValue, 'day')
-    },
-
-    isMinDateDisabled() {
-      return (
-        this.minDate && dayjs(this.internalValue).isBefore(this.minDate, 'day')
-      )
-    },
-
-    isMaxDateDisabled() {
-      return (
-        this.maxDate && dayjs(this.internalValue).isAfter(this.maxDate, 'day')
-      )
-    },
-
-    isDateDisabled() {
-      return !!(
-        this.isDateDisabledPast() ||
-        this.isMinDateDisabled() ||
-        this.isMaxDateDisabled()
-      )
     },
 
     $_wrapClose(e) {

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -89,6 +89,8 @@
 import dayjs from 'dayjs'
 import timezone from 'dayjs/plugin/timezone'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore'
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter'
 import utc from 'dayjs/plugin/utc'
 
 import { ClickOutside, Tooltip } from '../../directives'
@@ -106,6 +108,8 @@ import { datepickerOptions, INTERNAL_VIEWS } from './utils'
 
 dayjs.extend(timezone)
 dayjs.extend(customParseFormat)
+dayjs.extend(isSameOrBefore)
+dayjs.extend(isSameOrAfter)
 dayjs.extend(utc)
 
 export default {
@@ -438,23 +442,30 @@ export default {
       if (this.internalValue === 'Invalid Date') this.internalValue = ''
     },
 
-    isDateDisabled() {
-      let valid = false
-      if (this.disabledPast && dayjs().isAfter(this.internalValue, 'day')) {
-        valid = true
-      } else if (
+    isDateDisabledPast() {
+      return this.disabledPast && dayjs().isAfter(this.internalValue, 'day')
+    },
+
+    isMinDateDisabled() {
+      return (
         this.minDate &&
         dayjs(this.internalValue).isSameOrBefore(this.minDate, 'day')
-      ) {
-        valid = true
-      } else if (
+      )
+    },
+
+    isMaxDateDisabled() {
+      return (
         this.maxDate &&
         dayjs(this.internalValue).isSameOrAfter(this.maxDate, 'day')
-      ) {
-        valid = true
-      }
+      )
+    },
 
-      return valid
+    isDateDisabled() {
+      return !!(
+        this.isDateDisabledPast() ||
+        this.isMinDateDisabled() ||
+        this.isMaxDateDisabled()
+      )
     },
 
     $_wrapClose(e) {

--- a/src/components/Datepicker/components/DatepickerDays.vue
+++ b/src/components/Datepicker/components/DatepickerDays.vue
@@ -113,23 +113,24 @@ export default {
       return _day === 0 ? 7 : _day
     },
 
-    isDisabledDay(dateValue) {
-      let disabled = false
-      if (this.disabledPast && dayjs().isAfter(dateValue, 'day')) {
-        disabled = true
-      } else if (
-        this.minDate &&
-        dayjs(dateValue).isBefore(this.minDate, 'day')
-      ) {
-        disabled = true
-      } else if (
-        this.maxDate &&
-        dayjs(dateValue).isAfter(this.maxDate, 'day')
-      ) {
-        disabled = true
-      }
+    isDateDisabledPast(dateValue) {
+      return this.disabledPast && dayjs().isAfter(dateValue, 'day')
+    },
 
-      return disabled
+    isMinDateDisabled(dateValue) {
+      return this.minDate && dayjs(dateValue).isBefore(this.minDate, 'day')
+    },
+
+    isMaxDateDisabled(dateValue) {
+      return this.maxDate && dayjs(dateValue).isAfter(this.maxDate, 'day')
+    },
+
+    isDisabledDay(dateValue) {
+      return !!(
+        this.isDateDisabledPast(dateValue) ||
+        this.isMinDateDisabled(dateValue) ||
+        this.isMaxDateDisabled(dateValue)
+      )
     },
   },
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
In this PR I extend the **isSameOrAfter** and **isSameOrBefore** functions from the **dayjs** package so that the error described in the task does not happen, I added the expected format in the **minDate** and **maxDate** attributes in the documentation and I also refactored two methods that were flagged by sonar lint.

## Pull request type

Jira Link: [INT-588 - Design System - Error when filling minDate with the wrong format in documentation](https://storyblok.atlassian.net/browse/INT-588)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

https://user-images.githubusercontent.com/8209305/188719776-4055ed5f-89c7-402a-9373-cc37998ea68c.mov



## Other information
