### PR TITLE
feat: sb select emit a load-more event when the user scroll till the end of the list of items

### DIFF
--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -66,7 +66,7 @@
       :show-caption="showCaption"
       :item-caption="itemCaption"
       :show-list-on-top="showListOnTop"
-      :infinite-scroll="infiniteScroll"
+      :is-loading-more="isLoadingMore"
       :loading-more-text="loadingMoreText"
       @emit-value="handleEmitValue"
       @option-created="handleOptionCreated"
@@ -192,6 +192,7 @@ export default {
       default: 'caption',
     },
     infiniteScroll: Boolean,
+    isLoadingMore: Boolean,
     loadingMoreText: {
       type: String,
       default: 'Loading more...',

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -50,6 +50,7 @@
     <SbSelectList
       v-if="!useMinibrowser"
       ref="list"
+      v-infinite-scroll="{ handler: handleInfiniteScroll }"
       :value="value"
       :is-loading="isLoading"
       :search-input="searchInput"
@@ -83,7 +84,7 @@
 
 <script>
 import { debounce } from 'throttle-debounce'
-import { ClickOutside } from '../../directives'
+import { ClickOutside, InfiniteScroll } from '../../directives'
 import { canUseDOM, includes, toLowerCase, isString } from '../../utils'
 import SbSelectInner from './components/SelectInner'
 import SbSelectList from './components/SelectList'
@@ -93,6 +94,7 @@ export default {
 
   directives: {
     ClickOutside,
+    InfiniteScroll,
   },
 
   components: {
@@ -595,6 +597,13 @@ export default {
 
       this.$_focusInner()
       this.hideList()
+    },
+
+    /**
+     * emit a load-more event when the user scroll till the end of the list of items
+     */
+    handleInfiniteScroll() {
+      this.$emit('load-more')
     },
   },
 }

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -66,6 +66,8 @@
       :show-caption="showCaption"
       :item-caption="itemCaption"
       :show-list-on-top="showListOnTop"
+      :infinite-scroll="infiniteScroll"
+      :loading-more-text="loadingMoreText"
       @emit-value="handleEmitValue"
       @option-created="handleOptionCreated"
       @focus-item="focusAtIndex($event)"
@@ -188,6 +190,11 @@ export default {
     itemCaption: {
       type: String,
       default: 'caption',
+    },
+    infiniteScroll: Boolean,
+    loadingMoreText: {
+      type: String,
+      default: 'Loading more...',
     },
   },
 
@@ -603,7 +610,9 @@ export default {
      * emit a load-more event when the user scroll till the end of the list of items
      */
     handleInfiniteScroll() {
-      this.$emit('load-more')
+      if (this.infiniteScroll) {
+        this.$emit('load-more')
+      }
     },
   },
 }

--- a/src/components/Select/components/SelectList.vue
+++ b/src/components/Select/components/SelectList.vue
@@ -35,7 +35,7 @@
           "{{ searchInput }}"
         </span>
       </li>
-      <li v-else-if="showLoadingMoreText">
+      <li v-else-if="isLoadingMore">
         <span class="sb-select-list__empty">
           <SbLoading color="primary" size="small" />
           {{ loadingMoreText }}
@@ -109,7 +109,7 @@ export default {
       default: 'path',
     },
     showListOnTop: Boolean,
-    infiniteScroll: Boolean,
+    isLoadingMore: Boolean,
     loadingMoreText: {
       type: String,
       required: true,
@@ -172,10 +172,6 @@ export default {
         this.allowCreate &&
         this.multiple
       )
-    },
-
-    showLoadingMoreText() {
-      return this.infiniteScroll && this.hasOptions && this.isLoading
     },
   },
 

--- a/src/components/Select/components/SelectList.vue
+++ b/src/components/Select/components/SelectList.vue
@@ -35,6 +35,12 @@
           "{{ searchInput }}"
         </span>
       </li>
+      <li v-else-if="showLoadingMoreText">
+        <span class="sb-select-list__empty">
+          <SbLoading color="primary" size="small" />
+          {{ loadingMoreText }}
+        </span>
+      </li>
       <li v-else-if="showTextStartingTagCreation">
         <span class="sb-select-list__empty"> {{ noDataTextTag }} </span>
       </li>
@@ -103,6 +109,11 @@ export default {
       default: 'path',
     },
     showListOnTop: Boolean,
+    infiniteScroll: Boolean,
+    loadingMoreText: {
+      type: String,
+      required: true,
+    },
   },
 
   data() {
@@ -161,6 +172,10 @@ export default {
         this.allowCreate &&
         this.multiple
       )
+    },
+
+    showLoadingMoreText() {
+      return this.infiniteScroll && this.hasOptions && this.isLoading
     },
   },
 

--- a/src/components/Select/select.scss
+++ b/src/components/Select/select.scss
@@ -323,6 +323,11 @@
     color: $sb-dark-blue-50;
     font-size: 1.3rem;
     text-align: center;
+
+    .sb-loading {
+      display: inline-block;
+      margin-right: 10px;
+    }
   }
 }
 

--- a/src/directives/index.js
+++ b/src/directives/index.js
@@ -1,2 +1,3 @@
 export { default as ClickOutside } from './click-outside'
 export { default as Tooltip } from './tooltip'
+export { default as InfiniteScroll } from './infinite-scroll'

--- a/src/directives/infinite-scroll.js
+++ b/src/directives/infinite-scroll.js
@@ -1,0 +1,146 @@
+import { debounce } from 'throttle-debounce'
+
+/**
+ * @method getScrollTop
+ * @param  {Element} element
+ * @return {Number}
+ */
+const getScrollTop = function (element) {
+  if (element === window) {
+    return Math.max(window.pageYOffset || 0, document.documentElement.scrollTop)
+  }
+
+  return element.scrollTop
+}
+
+const getComputedStyle = document.defaultView.getComputedStyle
+
+/**
+ * @method getScrollEventTarget
+ * @param  {Element} element
+ * @return {Element | Window}
+ */
+const getScrollEventTarget = function (element) {
+  let currentNode = element
+  // bugfix, see http://w3help.org/zh-cn/causes/SD9013 and http://stackoverflow.com/questions/17016740/onscroll-function-is-not-working-for-chrome
+  while (
+    currentNode &&
+    currentNode.tagName !== 'HTML' &&
+    currentNode.tagName !== 'BODY' &&
+    currentNode.nodeType === 1
+  ) {
+    const overflowY = getComputedStyle(currentNode).overflowY
+    if (overflowY === 'scroll' || overflowY === 'auto') {
+      return currentNode
+    }
+    currentNode = currentNode.parentNode
+  }
+  return window
+}
+
+/**
+ * @method getVisibleHeight
+ * @param  {Element} element
+ * @return {Number}
+ */
+const getVisibleHeight = function (element) {
+  if (element === window) {
+    return document.documentElement.clientHeight
+  }
+
+  return element.clientHeight
+}
+
+const getElementTop = function (element) {
+  if (element === null) {
+    return
+  }
+  if (element === window) {
+    return getScrollTop(window)
+  }
+  return element.getBoundingClientRect().top + getScrollTop(window)
+}
+
+/**
+ * @method getListener
+ * @param  {Element} el
+ * @return {Function}
+ */
+const getListener = (el) => (_) => {
+  const scrollEventTarget = el.__infiniteScroll.scrollEventTarget
+  const distance = el.__infiniteScroll.distance
+
+  const viewportScrollTop = getScrollTop(scrollEventTarget)
+  const viewportBottom = viewportScrollTop + getVisibleHeight(scrollEventTarget)
+
+  let shouldTrigger = false
+
+  if (scrollEventTarget === el) {
+    shouldTrigger = scrollEventTarget.scrollHeight - viewportBottom <= distance
+  } else {
+    const elementBottom =
+      getElementTop(el) -
+      getElementTop(scrollEventTarget) +
+      el.offsetHeight +
+      viewportScrollTop
+
+    shouldTrigger = viewportBottom + distance >= elementBottom
+  }
+
+  if (shouldTrigger) {
+    el.__infiniteScroll.handler()
+  }
+}
+
+const InfiniteScroll = {
+  /**
+   * @typedef  {Object} InfiniteScrollOptions
+   * @property {Function} handler
+   * @property {Number} distance
+   *
+   * @method inserted
+   * @param  {Element} el element binded to directive
+   * @param  {{ value: InfiniteScrollOptions }} binding  object with arguments to directive
+   */
+  inserted(el, binding) {
+    if (typeof binding.value.handler !== 'function') {
+      console.warn(
+        '[v-infinite-scroll] - it should need to specify a function as a handler'
+      )
+      return
+    }
+
+    el.__infiniteScroll = {
+      distance: binding.value.distance || 100,
+      handler: binding.value.handler,
+      scrollListener: null,
+      scrollEventTarget: null,
+    }
+
+    el.__infiniteScroll.scrollEventTarget = getScrollEventTarget(el)
+    el.__infiniteScroll.scrollListener = debounce(200, getListener(el))
+    el.__infiniteScroll.scrollEventTarget.addEventListener(
+      'scroll',
+      el.__infiniteScroll.scrollListener
+    )
+  },
+
+  /**
+   * @method unbind
+   * @param  {Element} el element binded to directive
+   */
+  unbind(el) {
+    if (!el.__infiniteScroll) return
+
+    if (el.__infiniteScroll.scrollEventTarget) {
+      el.__infiniteScroll.scrollEventTarget.removeEventListener(
+        'scroll',
+        el.__infiniteScroll.scrollListener
+      )
+    }
+
+    delete el.__infiniteScroll
+  },
+}
+
+export default InfiniteScroll


### PR DESCRIPTION
Triggering a load-more event to give the capability to implement an infinite load

## Pull request type

Jira Link: [WORK-516](https://storyblok.atlassian.net/browse/WORK-516)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

1. click the SbSelect it should show the list of items
2. scroll to the end of the list, it should trigger a load-more event

## What is the new behavior?

- Must emit a load-more event when the user scrolls till the end of the list of items

## Other information
