### PR TITLE
hotfix(datepicker): back with clear icon and emit the empty value when the user clears the input

### DIFF
--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -11,7 +11,7 @@
         v-model="internalValue"
         :mask="internalMask"
         type="text"
-        icon-right="calendar"
+        icon-left="calendar"
         :disabled="disabled"
         :placeholder="placeholder"
         :value="internalValueFormatted"

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -16,6 +16,7 @@
         :placeholder="placeholder"
         :value="internalValueFormatted"
         :error="invalidDate"
+        clearable
         @icon-click="handleInputClick"
         @clear="handleClear"
         @keyup.enter="handleDoneAction"
@@ -315,6 +316,11 @@ export default {
 
     handleDoneAction() {
       let utcTime
+
+      if (this.internalValue === '') {
+        this.handleClear()
+        return
+      }
 
       const isValid = dayjs(
         this.internalValue,

--- a/src/components/Datepicker/datepicker.scss
+++ b/src/components/Datepicker/datepicker.scss
@@ -95,14 +95,6 @@
       background-color: $color-primary;
     }
   }
-
-  .sb-textfield__icon--clearable {
-    right: 40px;
-  }
-
-  .sb-textfield {
-    padding-right: 70px;
-  }
 }
 
 .sb-datepicker-header {

--- a/src/components/Datepicker/datepicker.scss
+++ b/src/components/Datepicker/datepicker.scss
@@ -33,7 +33,7 @@
     cursor: no-drop;
 
     &:hover {
-      background-color: white;
+      background-color: $white;
     }
   }
 }
@@ -49,7 +49,7 @@
     position: relative;
 
     .sb-textfield__icon {
-      cursor: pointer
+      cursor: pointer;
     }
   }
 
@@ -91,10 +91,17 @@
     }
 
     &--primary {
-      color: white;
+      color: $white;
       background-color: $color-primary;
     }
+  }
 
+  .sb-textfield__icon--clearable {
+    right: 40px;
+  }
+
+  .sb-textfield {
+    padding-right: 70px;
   }
 }
 

--- a/src/components/TextField/SbTextField.vue
+++ b/src/components/TextField/SbTextField.vue
@@ -97,6 +97,7 @@
       <SbIcon
         v-if="showClearIcon"
         v-tooltip="{ label: 'Clear' }"
+        class="sb-textfield__icon--clearable"
         name="x-clear"
         :class="computedIconClasses"
         :color="iconColor"

--- a/src/components/TextField/SbTextField.vue
+++ b/src/components/TextField/SbTextField.vue
@@ -97,9 +97,8 @@
       <SbIcon
         v-if="showClearIcon"
         v-tooltip="{ label: 'Clear' }"
-        class="sb-textfield__icon--clearable"
         name="x-clear"
-        :class="computedIconClasses"
+        :class="computedClearIconClasses"
         :color="iconColor"
         @click="handleClearableClick"
       />
@@ -179,11 +178,12 @@ export default {
       return this.computedValue !== null && ('' + this.computedValue).length > 0
     },
 
-    computedIconClasses() {
+    computedClearIconClasses() {
       return [
         'sb-textfield__icon',
         'sb-textfield__icon--right',
         'sb-textfield__icon--pointer',
+        'sb-textfield__icon--clearable',
       ]
     },
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [STR-1374](https://storyblok.atlassian.net/browse/STR-1374)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

In this PR, I'm getting back with the clear icon to make it possible to clear the datepicker. Also, as I was checking, it seems that we use the blur event to propagate to the parent component the new value. So, in there, I've just checked if the value is empty (so the user cleared the input) and then do the clear things.

This is the final result:

![image](https://user-images.githubusercontent.com/20342656/193067385-d23f5993-2989-439b-a2e3-8042c317e8af.png)

In the end, it is possible to clear the Datepicker:

* Clearing the textfield input
* Clicking on the Clear icon

## Other information
