### PR TITLE
Feat(ON-822): add feature to show a lock icon instead of checkbox

### DIFF
--- a/src/components/DataTable/DataTable.stories.js
+++ b/src/components/DataTable/DataTable.stories.js
@@ -24,6 +24,9 @@ const description = {
     'By default the selection mode is single, meaning only one row at a time can be selected. Use multiple, so multiple rows can be selected. `allowSelection: true` is required.',
   striped: 'Add zebra-striping to any table row within the `<tbody>.`',
   stickyMenu: 'Fixes the actions menu at the top when scrolling down',
+  lockedItem:
+    'Shows a lock icon instead of the checkbox input for specific items from the items prop that have "selectable: false" inside the object.',
+  hideActionsMenu: 'Hides the blue actions menu on the top of the Data Table',
 }
 
 const DataTableTemplate = (args) => ({
@@ -42,7 +45,8 @@ const DataTableTemplate = (args) => ({
         hideHeader,
         hideLabelActionsBreakpoint,
         striped,
-        stickyMenu
+        stickyMenu,
+        hideActionsMenu,
       }"
     />
   `,
@@ -71,6 +75,7 @@ export default {
     selectionMode: 'single',
     striped: false,
     stickyMenu: false,
+    hideActionsMenu: false,
   },
   argTypes: {
     actions: {
@@ -138,6 +143,13 @@ export default {
     stickyMenu: {
       name: 'stickyMenu',
       description: description.stickyMenu,
+      control: {
+        type: 'boolean',
+      },
+    },
+    hideActionsMenu: {
+      name: 'hideActionsMenu',
+      description: description.hideActionsMenu,
       control: {
         type: 'boolean',
       },
@@ -304,6 +316,76 @@ SelectionMode.parameters = {
   docs: {
     description: {
       story: description.selectionMode,
+    },
+  },
+}
+
+export const LockedItem = DataTableTemplate.bind({})
+
+LockedItem.args = {
+  ...Default.args,
+  allowSelection: true,
+  selectionMode: 'multiple',
+  striped: true,
+  items: [
+    {
+      name: 'French Fries',
+      calories: 261,
+      fat: 1.0,
+      carbs: 21,
+      protein: 3.0,
+      iron: '2%',
+      selectable: false,
+    },
+    {
+      name: 'Hamburger',
+      calories: 271,
+      fat: 1.2,
+      carbs: 22,
+      protein: 4.0,
+      iron: '3%',
+    },
+    {
+      name: 'Chocolate Pizza',
+      calories: 244,
+      fat: 1.4,
+      carbs: 277,
+      protein: 8.0,
+      iron: '1%',
+    },
+    {
+      name: 'Green Tea',
+      calories: 1,
+      fat: 1,
+      carbs: 100,
+      protein: 4.0,
+      iron: '2%',
+      selectable: false,
+    },
+  ],
+}
+
+LockedItem.parameters = {
+  docs: {
+    description: {
+      story: description.lockedItem,
+    },
+  },
+}
+
+export const HideActionsMenu = DataTableTemplate.bind({})
+
+HideActionsMenu.args = {
+  ...Default.args,
+  allowSelection: true,
+  selectionMode: 'multiple',
+  hideActionsMenu: true,
+}
+
+HideActionsMenu.parameters = {
+  docs: {
+    description: {
+      story: description.hideActionsMenu,
     },
   },
 }

--- a/src/components/DataTable/components/SbDataTableBodyRow.vue
+++ b/src/components/DataTable/components/SbDataTableBodyRow.vue
@@ -6,11 +6,18 @@
     }"
   >
     <td
-      v-if="allowSelection"
+      v-if="allowSelection && row.selectable !== false"
       class="sb-data-table__body-cell sb-data-table__col-selection"
       @click="handleRowSelected"
     >
       <SbCheckbox :value="isSelected" @click="handleRowSelected" />
+    </td>
+
+    <td
+      v-else-if="allowSelection && row.selectable === false"
+      class="sb-data-table__body-cell sb-data-table__col-locked"
+    >
+      <SbIcon name="lock" />
     </td>
 
     <slot v-if="$slots.default" />
@@ -31,6 +38,7 @@
 
 <script>
 import SbCheckbox from '../../Checkbox'
+import SbIcon from '../../Icon'
 import sharedProps from '../sharedProps'
 
 export default {
@@ -38,6 +46,7 @@ export default {
 
   components: {
     SbCheckbox,
+    SbIcon,
   },
 
   inject: ['dataTableContext'],

--- a/src/components/DataTable/data-table.scss
+++ b/src/components/DataTable/data-table.scss
@@ -8,6 +8,10 @@
     }
   }
 
+  &__col-locked svg {
+    margin-left: -4px;
+  }
+
   &__loading {
     position: absolute;
     bottom: 0;

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -32,10 +32,14 @@ const SbDataTable = {
 
   computed: {
     allRowsSelected() {
+      const selectableItems = this.items.filter(
+        (item) => item.selectable !== false
+      )
+
       if (this.selectionMode === 'single' || !this.selectedRows.length)
         return false
 
-      return this.selectedRows.length === this.items.length &&
+      return this.selectedRows.length === selectableItems.length &&
         this.hasSelectedRowsInList.length
         ? true
         : null
@@ -146,7 +150,7 @@ const SbDataTable = {
      * method to select all body row(s)
      */
     selectAll() {
-      this.selectedRows = [...this.items]
+      this.selectedRows = this.items.filter((item) => item.selectable !== false)
     },
 
     /**
@@ -175,21 +179,23 @@ const SbDataTable = {
 
   render(h) {
     const renderActions = () => {
-      return h(SbDataTableActions, {
-        props: {
-          actions: this.actions,
-          hideLabelActionsBreakpoint: this.hideLabelActionsBreakpoint,
-          selectedRows: this.hasSelectedRowsInList,
-          sticky: this.stickyMenu,
-        },
-        on: {
-          click: (value) => this.$emit('emit-action', value),
-          cancel: () => {
-            this.$emit('cancel')
-            this.deselectAll()
-          },
-        },
-      })
+      return this.hideActionsMenu
+        ? null
+        : h(SbDataTableActions, {
+            props: {
+              actions: this.actions,
+              hideLabelActionsBreakpoint: this.hideLabelActionsBreakpoint,
+              selectedRows: this.hasSelectedRowsInList,
+              sticky: this.stickyMenu,
+            },
+            on: {
+              click: (value) => this.$emit('emit-action', value),
+              cancel: () => {
+                this.$emit('cancel')
+                this.deselectAll()
+              },
+            },
+          })
     }
 
     const renderTable = () => {

--- a/src/components/DataTable/sharedProps.js
+++ b/src/components/DataTable/sharedProps.js
@@ -53,4 +53,8 @@ export default {
     type: Boolean,
     default: false,
   },
+  hideActionsMenu: {
+    type: Boolean,
+    default: false,
+  },
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [ON-822](https://storyblok.atlassian.net/browse/ON-822)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

For the locked items [go here](https://storyblok-design-system-git-feat-on-822-sh-271bb5-storyblok-com.vercel.app/?path=/story/design-system-components-sbdatatable--locked-item) and check if it's not possible to select the items with the locker items. Also check if the when using the header selection the locked items are not counted to the selected items amount.

![Captura de Tela 2022-10-07 às 13 12 46](https://user-images.githubusercontent.com/26799272/194599642-218854ec-cf6f-462a-ab45-b5b905232d54.png)

For the hiding of the actions menu [go here ](https://storyblok-design-system-git-feat-on-822-sh-271bb5-storyblok-com.vercel.app/?path=/story/design-system-components-sbdatatable--hide-actions-menu) and check if the blue bar (actions menu) is not showing.

![Captura de Tela 2022-10-07 às 13 12 38](https://user-images.githubusercontent.com/26799272/194599689-0e49b18d-9932-4347-96a2-48a75308728b.png)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- add feature to show a lock icon instead of the checkbox so the locked icons are not selectable
- add prop to hide the actions menu
- 

## Other information
