### PR TITLE
fix(work-573): don't show a tag if the value is not present in the op…

### DIFF
--- a/src/components/Select/__tests__/Select.spec.js
+++ b/src/components/Select/__tests__/Select.spec.js
@@ -202,6 +202,17 @@ describe('SbSelect component', () => {
 
       expect(wrapper.emitted('input')[0][0]).toEqual([])
     })
+
+    it('should not show a tag if the value are not included in the list of available options to choose', () => {
+      const wrapper = mountAttachingComponent(SbSelect, {
+        propsData: {
+          ...defaultsPropsData,
+          value: [10902],
+        },
+      })
+
+      expect(wrapper.findAllComponents(SbTag)).toHaveLength(0)
+    })
   })
 
   describe('leftIcon property', () => {

--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -246,7 +246,7 @@ export default {
     },
 
     placeholderLabel() {
-      if (!this.hasValue) {
+      if (!this.hasValue || (this.multiple && !this.tagLabels.length)) {
         if (this.isLoading && this.loadingLabel) {
           return this.loadingLabel
         }

--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -294,19 +294,23 @@ export default {
         return []
       }
 
-      return this.value.map(($v) => {
-        if (typeof $v === 'object') {
-          return $v
-        }
+      return this.value
+        .map(($v) => {
+          if (typeof $v === 'object') {
+            return $v
+          }
 
-        const option = this.options.find(($opt) => $opt[this.itemValue] === $v)
+          const option = this.options.find(
+            ($opt) => $opt[this.itemValue] === $v
+          )
 
-        if (this.allowCreate && !option) {
-          return this.emitOption ? { [this.itemValue]: $v } : $v
-        }
+          if (this.allowCreate && !option) {
+            return this.emitOption ? { [this.itemValue]: $v } : $v
+          }
 
-        return option
-      })
+          return option
+        })
+        .filter((option) => option !== null && option !== undefined)
     },
 
     isAvatarVisible() {

--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -295,20 +295,22 @@ export default {
       }
 
       return this.value
-        .map(($v) => {
-          if (typeof $v === 'object') {
-            return $v
+        .map((value) => {
+          if (typeof value === 'object') {
+            return value
           }
 
-          const option = this.options.find(
-            ($opt) => $opt[this.itemValue] === $v
+          const selectedOption = this.options.find(
+            (option) => option[this.itemValue] === value
           )
 
-          if (this.allowCreate && !option) {
-            return this.emitOption ? { [this.itemValue]: $v } : $v
+          const shouldCreate = this.allowCreate && !selectedOption
+
+          if (shouldCreate) {
+            return this.emitOption ? { [this.itemValue]: value } : value
           }
 
-          return option
+          return selectedOption
         })
         .filter((option) => option !== null && option !== undefined)
     },


### PR DESCRIPTION
SbSelect component shows an empty tag.

If the SbSelect has a value that is not in the list of options anymore, it shows an empty tag.

## Pull request type

Jira Link: [WORK-573](https://storyblok.atlassian.net/browse/WORK-573)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

1. in the design system select the [Multiple option variant of the SbSelect](https://storyblok-design-system-git-feature-str-325-storyblok-com.vercel.app/?path=/story/design-system-components-form-sbselect--multiple)
2. change the value property
3. add a value that is not on the list of options


https://user-images.githubusercontent.com/7618411/195673865-baaa914c-3efb-4d57-8d1f-8e4227ab4cb5.mov



## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

It must not show an empty tag when the value is not present on the list of items.

https://user-images.githubusercontent.com/7618411/195675564-4c2419e8-9557-425c-9d26-26d2814f09b0.mov




## Other information
