### PR TITLE
fix(on-857): changed SbMoreAvatars click event payload and fixes event emitted twice

### DIFF
--- a/src/components/AvatarGroup/SbAvatarGroup.vue
+++ b/src/components/AvatarGroup/SbAvatarGroup.vue
@@ -11,7 +11,7 @@
       ref="moreAvatars"
       :avatars="hiddenAvatars"
       :label="moreAvatarsLabel"
-      @click="handleMoreAvatarsClick"
+      @toggle-avatars-dropdown="handleMoreAvatarsClick"
       @keydown="handleMoreAvatarsKeydown"
     />
   </div>
@@ -102,8 +102,11 @@ export default {
       }
     },
 
-    handleMoreAvatarsClick(event, vm) {
-      this.$emit('click', event, vm)
+    handleMoreAvatarsClick() {
+      this.isVisibleDropdown = !this.isVisibleDropdown
+      this.$emit('toggle-visible-dropdown', {
+        isVisibleDropdown: this.isVisibleDropdown,
+      })
     },
 
     handleMoreAvatarsKeydown(event) {

--- a/src/components/AvatarGroup/components/SbMoreAvatars.vue
+++ b/src/components/AvatarGroup/components/SbMoreAvatars.vue
@@ -81,18 +81,15 @@ export default {
       }
     },
 
-    closeAvatarsList() {
-      this.expanded = false
-    },
-
-    handleClick(event) {
+    handleClick() {
       this.toggleExpanded()
-
-      this.$emit('click', event, this)
     },
 
     toggleExpanded() {
       this.expanded = !this.expanded
+      this.$emit('toggle-avatars-dropdown', {
+        isExpanded: this.expanded,
+      })
     },
 
     handleClickOutside(event) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [ON-857](https://storyblok.atlassian.net/browse/ON-857)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
Since no new feature (or feature change) is being introduced in this PR, there is no specific behavior to test.
Just make sure the component still works as in production 🙂 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The `<SbMoreAvatars/>` click event handler was sent twice. It is fixed with this PR:

#### Before:
https://user-images.githubusercontent.com/16685155/198594404-e708c53d-3330-4599-bd5b-71cfcf87ba3b.mov

#### After: 
https://user-images.githubusercontent.com/16685155/198594552-c355a4a5-49bd-423f-92e9-118cf4c1164c.mov


- No new behavior, the component just sends more data in the click event payload. _(for an additional external need)_**

## Other information

Linked to [a PR on the _storyfront_ repo](https://github.com/storyblok/storyfront/pull/2625)