### PR TITLE
fix: remove id from checkboxes

### DIFF
--- a/src/components/Toggle/SbToggle.vue
+++ b/src/components/Toggle/SbToggle.vue
@@ -1,19 +1,20 @@
 <template>
   <div class="sb-toggle" :class="componentClasses">
-    <input
-      :id="id"
-      v-model="computedValue"
-      v-bind="$attrs"
-      :indeterminate.prop="indeterminate"
-      class="sb-toggle__native"
-      type="checkbox"
-      :name="name"
-      :value="nativeValue"
-      :required="required"
-      :disabled="disabled"
-      @click.stop
-    />
-    <label :for="id" class="sb-toggle__label">{{ label }}</label>
+    <label>
+      <input
+        v-model="computedValue"
+        v-bind="$attrs"
+        :indeterminate.prop="indeterminate"
+        class="sb-toggle__native"
+        type="checkbox"
+        :name="name"
+        :value="nativeValue"
+        :required="required"
+        :disabled="disabled"
+        @click.stop
+      />
+      <span class="sb-toggle__label">{{ label }}</span>
+    </label>
     <SbIcon
       v-if="icon"
       class="sb-toggle__icon sb-toggle__icon--active"


### PR DESCRIPTION
I removed the id because if we have more than one checkbox in the page loaded by other components instances the IDs are conflicting

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

It does not have a ticket related but it's needed for this one:
Jira Link: [FT-6](https://storyblok.atlassian.net/browse/FT-6) 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

I don't know how you could test this but basically you need to have a richtext field and in the same page another field that uses the same checkbox. In my case it's happening on the feature work for the custom attributes of the link so you can download the main project and switch to the branch related to the issue linked above and then point the DS to this branch. it's the checkbox for the target blank that has been moved inside the multilink fields and so now we can have multiple instances of the checkbox in the page.

For anything let me know.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- 
- 
- 

## Other information
