### PR TITLE
fix(str-286): fix unrounded positioning of popper

### DIFF
--- a/src/components/Popover/index.js
+++ b/src/components/Popover/index.js
@@ -109,6 +109,12 @@ const SbPopover = {
             offset: this.offset,
           },
         },
+        {
+          name: 'computeStyles',
+          options: {
+            adaptive: false,
+          },
+        },
         arrow,
         hide,
       ]

--- a/src/components/Popover/index.js
+++ b/src/components/Popover/index.js
@@ -113,6 +113,10 @@ const SbPopover = {
           name: 'computeStyles',
           options: {
             adaptive: false,
+            roundOffsets: ({ x, y }) => ({
+              x: Math.round(x),
+              y: Math.round(y - 1),
+            }),
           },
         },
         arrow,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [STR-286](https://storyblok.atlassian.net/browse/STR-286)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

from ticket:
```
can we make sure we always have rounded number, so we don’t get position -64.4333px but -64px.
If we have  64.4333 interface looks blurry
```

We might need to check/test all places where the popover is used. I think this has the potential to add other unwanted behavior.

For more detail, read this documentation about the adaptive behaviour: https://popper.js.org/docs/v2/modifiers/compute-styles/#adaptive

## Other information
