### PR TITLE
fix(str-1475): fix SbSelect to deal properly with created options

### DIFF
--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -391,12 +391,24 @@ export default {
      * @param {Array<String>|String} value
      */
     handleEmitValue(value) {
-      // doesn't close the list
       if (this.multiple) {
-        this.searchInput = ''
-        const $value = this.processMultipleValue(value)
+        const valueExists = this.options.find(
+          (option) =>
+            option === value ||
+            option[this.itemValue] === value ||
+            option[this.itemLabel] === value
+        )
 
-        this.$emit('input', this.validateValue($value, this.value))
+        if (valueExists) {
+          const parsedValue = this.emitOption ? valueExists : value
+          const inputValue = this.processMultipleValue(parsedValue)
+          this.$emit('input', this.validateValue(inputValue, this.value))
+        } else if (this.allowCreate) {
+          this.handleOptionCreated(value)
+        }
+
+        this.searchInput = ''
+
         return
       }
 
@@ -431,6 +443,7 @@ export default {
     handleOptionCreated(value) {
       this.searchInput = ''
       this.$emit('option-created', value)
+      if (this.multiple) return
       this.$_focusInner()
       this.hideList()
     },


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
This PR fixes the behavior of multiple SbSelect with allow-create prop set to true.

## Pull request type

Jira Link: [STR-1475 - Tag: Tag creation is not working](https://storyblok.atlassian.net/browse/STR-1475)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
<!-- Please provide the steps on how to test this PR. -->
The main steps can be found on the ticket.

**It's important to perform a regression tests on all `Multiple Select` scenarios within the application, to make sure everything is working as expected. These are the points:**

**⚠️  For QA (call me if any help is needed to go through the potential scenarios)**

_Base Select Occurrences_
<img width="851" alt="image" src="https://user-images.githubusercontent.com/4389464/186743716-4bf28a78-7a16-426a-a1de-babef1707a51.png">

_SbSelect occurrences_
<img width="769" alt="image" src="https://user-images.githubusercontent.com/4389464/186743857-0f12f9a8-6dc3-4163-9e74-10bfd75a7841.png">



## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- When the `SbSelect` is `multiple` and has `allow-create` set to `true`, the value will be properly created also when hitting `Enter` key.
## Other information
