### PR TITLE
feat(on-894): ✨ users' table UI update

### DIFF
--- a/src/components/DataTable/components/SbDataTableColumn.vue
+++ b/src/components/DataTable/components/SbDataTableColumn.vue
@@ -1,5 +1,5 @@
 <template>
-  <td class="sb-data-table__body-cell" :width="width">
+  <td class="sb-data-table__body-cell" :class="computedClasses" :width="width">
     <slot :row="row" />
   </td>
 </template>
@@ -26,6 +26,15 @@ export default {
     width: {
       type: String,
       default: null,
+    },
+    isContentCentered: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    computedClasses() {
+      return this.isContentCentered ? 'sb-data-table__body-cell--centered' : ''
     },
   },
 }

--- a/src/components/DataTable/components/SbDataTableHeaderCell.vue
+++ b/src/components/DataTable/components/SbDataTableHeaderCell.vue
@@ -1,7 +1,7 @@
 <template>
   <th
     class="sb-data-table__head-cell"
-    :class="{ 'sb-data-table--show-icon': showSortIcon }"
+    :class="computedClasses"
     @click="toggleSort"
   >
     <div v-if="hasHeaderSlot" class="sb-data-table__header-template">
@@ -73,6 +73,17 @@ export default {
 
     hasHeaderSlot() {
       return this.column?.scopedSlots?.header
+    },
+
+    computedClasses() {
+      let classesList = []
+      if (this.showSortIcon) {
+        classesList = [...classesList, 'sb-data-table--show-icon']
+      }
+      if (this.column?.isContentCentered) {
+        classesList = [...classesList, 'sb-data-table__head-cell--centered']
+      }
+      return classesList
     },
   },
 

--- a/src/components/DataTable/components/SbDataTableHeaderCell.vue
+++ b/src/components/DataTable/components/SbDataTableHeaderCell.vue
@@ -83,6 +83,9 @@ export default {
       if (this.column?.isContentCentered) {
         classesList = [...classesList, 'sb-data-table__head-cell--centered']
       }
+      if (this.column?.sortable) {
+        classesList = [...classesList, 'sb-data-table__head-cell--sortable']
+      }
       return classesList
     },
   },

--- a/src/components/DataTable/components/SbDataTableHeaderCell.vue
+++ b/src/components/DataTable/components/SbDataTableHeaderCell.vue
@@ -76,17 +76,11 @@ export default {
     },
 
     computedClasses() {
-      let classesList = []
-      if (this.showSortIcon) {
-        classesList = [...classesList, 'sb-data-table--show-icon']
+      return {
+        'sb-data-table--show-icon': this.showSortIcon,
+        'sb-data-table__head-cell--centered': this.column?.isContentCentered,
+        'sb-data-table__head-cell--sortable': this.column?.sortable,
       }
-      if (this.column?.isContentCentered) {
-        classesList = [...classesList, 'sb-data-table__head-cell--centered']
-      }
-      if (this.column?.sortable) {
-        classesList = [...classesList, 'sb-data-table__head-cell--sortable']
-      }
-      return classesList
     },
   },
 

--- a/src/components/DataTable/data-table.scss
+++ b/src/components/DataTable/data-table.scss
@@ -121,18 +121,9 @@
 
   &__sort-icon {
     margin-left: 10px;
-    opacity: 0;
 
     .sb-data-table--show-icon & {
       opacity: 1;
-    }
-  }
-
-  &__head-cell {
-    &:hover {
-      .sb-data-table__sort-icon {
-        opacity: 1;
-      }
     }
   }
 

--- a/src/components/DataTable/data-table.scss
+++ b/src/components/DataTable/data-table.scss
@@ -44,6 +44,13 @@
     }
   }
 
+  &__head-cell,
+  &__body-cell {
+    &--centered {
+      text-align: center;
+    }
+  }
+
   &--loading {
     position: relative;
 

--- a/src/components/DataTable/data-table.scss
+++ b/src/components/DataTable/data-table.scss
@@ -54,6 +54,7 @@
   &__head-cell {
     &--sortable {
       cursor: pointer;
+      white-space: nowrap;
     }
   }
 
@@ -126,10 +127,18 @@
   }
 
   &__sort-icon {
-    margin-left: 10px;
+    opacity: 0;
 
     .sb-data-table--show-icon & {
       opacity: 1;
+    }
+  }
+
+  &__head-cell {
+    &:hover {
+      .sb-data-table__sort-icon {
+        opacity: 1;
+      }
     }
   }
 

--- a/src/components/DataTable/data-table.scss
+++ b/src/components/DataTable/data-table.scss
@@ -51,6 +51,12 @@
     }
   }
 
+  &__head-cell {
+    &--sortable {
+      cursor: pointer;
+    }
+  }
+
   &--loading {
     position: relative;
 

--- a/src/components/Modal/modal.scss
+++ b/src/components/Modal/modal.scss
@@ -18,7 +18,7 @@
   padding: 35px;
   background-color: $white;
   border-radius: 5px;
-  box-shadow: 0 2px 17px 3px rgba(34, 42, 69, 0.07);
+  box-shadow: $box-shadow-default;
   animation: fadein 0.3s;
 
   &--scrollbar {

--- a/src/components/Tag/SbTag.vue
+++ b/src/components/Tag/SbTag.vue
@@ -47,7 +47,7 @@ export default {
     },
     type: {
       type: String,
-      default: 'light',
+      default: 'light-grey',
       validator: (type) => includes(tagTypes, type),
     },
   },

--- a/src/components/Tag/lib.js
+++ b/src/components/Tag/lib.js
@@ -6,9 +6,11 @@ export const tagTypes = [
   'negative',
   'warning',
   'info',
-  'light',
+  'light-grey',
+  'dark-grey',
   'light-info',
   'success',
+  'dark-ink',
 ]
 
 /**
@@ -17,8 +19,10 @@ export const tagTypes = [
  * 'negative': string,
  * 'warning': string,
  * 'info': string,
- * 'light': string,
+ * 'light-grey': string,
+ * 'dark-grey': string,
  * 'light-info': string,
+ * 'dark-ink': string,
  * 'success': string,
  * }}
  */

--- a/src/components/Tag/tag.scss
+++ b/src/components/Tag/tag.scss
@@ -44,8 +44,16 @@
     @include setColor($blue, $white);
   }
 
-  &--light {
+  &--light-grey {
     @include setColor($light, $primary-text-color);
+  }
+
+  &--dark-grey {
+    @include setColor($neutral-gray, $white);
+  }
+
+  &--dark-ink {
+    @include setColor($color-primary-dark, $white);
   }
 
   &--light-info {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
## Pull request type

Jira Link: [ON-894](https://storyblok.atlassian.net/browse/ON-894)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please describe how others can test this PR -->
Using organization owner/admin/member & partner accounts.
- Access to :
  - Spaces > [choose a space] > Settings > Users
  - Organization > Team Management
  - Organization > Spaces > [choose a space] > Manage Users
  - Partner Portal > Team Management
- Check it matches [the design in Figma](https://www.figma.com/file/oz3GybPvOkpwebQTWN7ejl/%5BON-855%5D--Update-the-organization's-dashboard-UI?node-id=813%3A5022&t=xO7ZwxVIJtAc9rS8-1).
- Check if the component is working as before and that no regression has been made

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

#### Before the update :
<img width="1085" alt="Screenshot 2022-12-01 at 13 01 43" src="https://user-images.githubusercontent.com/16685155/205047788-c046d7b2-3256-4c2a-b4c3-e4e461cd7bec.png">


- New columns have been added to the users table: 
  - SSO
  - User status
  - The list of spaces in which the user is currently active :
<img width="248" alt="Screenshot 2022-12-01 at 12 59 39" src="https://user-images.githubusercontent.com/16685155/205047821-9db0e2e7-1a80-4914-aa94-828b46ef12ce.png">

- The actions buttons have been moved to a new dots menu :
<img width="101" alt="Screenshot 2022-12-01 at 12 59 44" src="https://user-images.githubusercontent.com/16685155/205047869-6db4c25b-3630-4624-b0e7-7d73d66fcb78.png">

- We can now hover over the active spaces list for each user and quickly the space names, IDs, and the role(s) of the user for each of them.

:warning: The user role is now hardcoded and waiting for the backend implementation in [ON-917](https://storyblok.atlassian.net/browse/ON-917). Hence, the "[Role in space]" static value.

<img width="1090" alt="Screenshot 2022-12-01 at 13 06 30" src="https://user-images.githubusercontent.com/16685155/205048725-fa8d4fe6-ce41-4b68-b188-aa24533b2773.png">

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR is linked to another PR on the _Storyfront_ repo: https://github.com/storyblok/storyfront/pull/2803

## For the reviewers

[Pull Request Checklist](https://www.notion.so/storyblok/Pull-Request-Checklist-caef66feee2f4ae3b898534c1e4c1275)