### PR TITLE
subtask(work-713): add tooltip in sidebar item

### DIFF
--- a/src/components/Sidebar/Sidebar.stories.js
+++ b/src/components/Sidebar/Sidebar.stories.js
@@ -15,6 +15,14 @@ export const listItemsData = [
     ariaLabel: 'Go to content',
   },
   {
+    href: '#tooltip',
+    icon: 'content',
+    label: 'Content tooltip',
+    iconTooltip: 'square-warning',
+    iconTooltipLabel: 'Label content tooltip',
+    ariaLabel: 'Go to content',
+  },
+  {
     href: '#apps',
     icon: 'apps',
     label: 'Apps Directory',

--- a/src/components/Sidebar/components/ListItem.vue
+++ b/src/components/Sidebar/components/ListItem.vue
@@ -38,6 +38,9 @@
         :icon="icon"
         :icon-right="iconRight"
         :icon-right-size="iconRightSize"
+        :icon-tooltip="iconTooltip"
+        :icon-tooltip-size="iconTooltipSize"
+        :icon-tooltip-label="iconTooltipLabel"
         :has-separator="hasSeparator"
         :label="label"
       />
@@ -98,6 +101,18 @@ export default {
     iconRightSize: {
       type: String,
       default: 'normal',
+    },
+    iconTooltip: {
+      type: String,
+      default: null,
+    },
+    iconTooltipSize: {
+      type: String,
+      default: 'normal',
+    },
+    iconTooltipLabel: {
+      type: String,
+      default: null,
     },
     to: {
       type: [String, Object],

--- a/src/components/Sidebar/components/ListItem.vue
+++ b/src/components/Sidebar/components/ListItem.vue
@@ -19,6 +19,9 @@
         :icon="icon"
         :icon-right="iconRight"
         :icon-right-size="iconRightSize"
+        :icon-tooltip="iconTooltip"
+        :icon-tooltip-size="iconTooltipSize"
+        :icon-tooltip-label="iconTooltipLabel"
         :has-separator="hasSeparator"
         :label="label"
       />

--- a/src/components/Sidebar/components/ListItemInner.vue
+++ b/src/components/Sidebar/components/ListItemInner.vue
@@ -8,6 +8,16 @@
 
     <span class="sb-sidebar-link__label">
       {{ label }}
+      <SbIcon
+        v-if="iconTooltip"
+        v-tooltip="{
+          label: iconTooltipLabel,
+          position: 'top',
+          variant: 'light',
+        }"
+        :size="iconTooltipSize"
+        :name="iconTooltip"
+      />
     </span>
 
     <SbIcon
@@ -50,6 +60,18 @@ export default {
     iconRightSize: {
       type: String,
       default: 'normal',
+    },
+    iconTooltip: {
+      type: String,
+      default: null,
+    },
+    iconTooltipSize: {
+      type: String,
+      default: 'normal',
+    },
+    iconTooltipLabel: {
+      type: String,
+      default: null,
     },
     hasSeparator: {
       type: Boolean,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
To complete task WORK-599 it is necessary to add an icon with tooltip in the sidebar item description and that is why I am opening this PR.

## Pull request type

Jira Link: [WORK-713](https://storyblok.atlassian.net/browse/WORK-713)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Go in: https://storyblok-design-system-7yzg9n40q-storyblok-com.vercel.app/?path=/story/design-system-components-sbsidebar--default

Check if one of the sidebar items contains an icon next to the description with the tooltip.

## Other information
