### PR TITLE
fix(ft-36): block minibrowser on loading

### DIFF
--- a/src/components/BlockUI/BlockUi.vue
+++ b/src/components/BlockUI/BlockUi.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="sb-block-ui" v-bind="$attrs" v-on="$listeners">
+  <div
+    class="sb-block-ui"
+    v-bind="$attrs"
+    :class="computedClass"
+    v-on="$listeners"
+  >
     <slot />
   </div>
 </template>
@@ -7,5 +12,20 @@
 <script>
 export default {
   name: 'SbBlockUi',
+
+  props: {
+    inElement: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  computed: {
+    computedClass() {
+      return {
+        'sb-block-ui--in-element': this.inElement,
+      }
+    },
+  },
 }
 </script>

--- a/src/components/BlockUI/block.scss
+++ b/src/components/BlockUI/block.scss
@@ -15,3 +15,8 @@
   padding: 20px;
   background-color: $black-trasparent;
 }
+
+.sb-block-ui--in-element {
+  position: absolute;
+  background-color: transparent;
+}

--- a/src/components/Minibrowser/Minibrowser.stories.js
+++ b/src/components/Minibrowser/Minibrowser.stories.js
@@ -412,3 +412,17 @@ Inline.args = {
     },
   ],
 }
+
+export const WithLoadingBlocking = MinibrowserTemplate.bind({})
+WithLoadingBlocking.args = {
+  isLoading: true,
+}
+
+WithLoadingBlocking.parameters = {
+  docs: {
+    description: {
+      story:
+        'When the `isLoading` prop is set to `true`, the minibrowser will be blocked for navigation and selection.',
+    },
+  },
+}

--- a/src/components/Minibrowser/Minibrowser.vue
+++ b/src/components/Minibrowser/Minibrowser.vue
@@ -17,6 +17,7 @@
     />
 
     <div class="sb-minibrowser__list-container">
+      <SbBlockUi v-if="isLoading" in-element />
       <SbMinibrowserBreadcrumbs
         v-if="hasBreadcrumbs"
         :items="internalBreadcrumbs"
@@ -55,7 +56,7 @@ import { flatten } from '../../utils'
 import SbMinibrowserSearch from './components/MinibrowserSearch'
 import SbMinibrowserList from './components/MinibrowserList'
 import SbMinibrowserBreadcrumbs from './components/MinibrowserBreadcrumbs'
-
+import SbBlockUi from '../BlockUI'
 /**
  * SbMinibrowser is a visualization of a structure ‘hierarchy’. User can view and search content pages, folders etc.
  */
@@ -66,6 +67,7 @@ export default {
     SbMinibrowserSearch,
     SbMinibrowserList,
     SbMinibrowserBreadcrumbs,
+    SbBlockUi,
   },
 
   provide() {
@@ -261,6 +263,7 @@ export default {
      * @param {Number} index
      */
     navigateTo(index = 0) {
+      if (this.isLoading) return
       this.$emit('navigate', index)
     },
 

--- a/src/components/Minibrowser/minibrowser.scss
+++ b/src/components/Minibrowser/minibrowser.scss
@@ -38,6 +38,10 @@ $full-height-padding: $general-padding - $padding-full-height-difference;
     }
   }
 
+  &__list-container {
+    position: relative;
+  }
+
   &__list ul {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [ft-36](https://storyblok.atlassian.net/browse/FT-36)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
There is a problem that the minibrowser can navigate to other places when it's still loading folders. With this change, the UI of the minibrowser list will be blocked when the loading state is true, so you can't navigate.

See here:

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- block the navigation when it's loading
- 
- 

## Other information
