### PR TITLE
feat(on-821): :sparkles: introduces sort icon always displayed in <th> logic

### DIFF
--- a/src/components/DataTable/components/SbDataTableColumn.vue
+++ b/src/components/DataTable/components/SbDataTableColumn.vue
@@ -1,5 +1,10 @@
 <template>
-  <td class="sb-data-table__body-cell" :class="computedClasses" :width="width">
+  <td
+    class="sb-data-table__body-cell"
+    :class="computedClasses"
+    :width="width"
+    :is-sort-icon-always-visible="isSortIconAlwaysVisible"
+  >
     <slot :row="row" />
   </td>
 </template>
@@ -28,6 +33,10 @@ export default {
       default: null,
     },
     isContentCentered: {
+      type: Boolean,
+      default: false,
+    },
+    isSortIconAlwaysVisible: {
       type: Boolean,
       default: false,
     },

--- a/src/components/DataTable/components/SbDataTableHeader.vue
+++ b/src/components/DataTable/components/SbDataTableHeader.vue
@@ -14,6 +14,7 @@
         :key="index"
         :column="elem"
         :sorted-key="sortedKey"
+        :is-sort-icon-always-visible="isSortIconAlwaysVisible"
       />
     </tr>
   </thead>
@@ -45,6 +46,10 @@ export default {
     },
     allRowsSelected: {
       required: false,
+      type: Boolean,
+      default: false,
+    },
+    isSortIconAlwaysVisible: {
       type: Boolean,
       default: false,
     },

--- a/src/components/DataTable/components/SbDataTableHeaderCell.vue
+++ b/src/components/DataTable/components/SbDataTableHeaderCell.vue
@@ -68,7 +68,10 @@ export default {
     },
 
     showSortIcon() {
-      return (this.isSortable && this.order && this.isSortedKey) || this.isSortIconAlwaysVisible
+      return (
+        (this.isSortable && this.order && this.isSortedKey) ||
+        (this.isSortable && this.isSortIconAlwaysVisible)
+      )
     },
 
     sortKey() {

--- a/src/components/DataTable/components/SbDataTableHeaderCell.vue
+++ b/src/components/DataTable/components/SbDataTableHeaderCell.vue
@@ -44,6 +44,10 @@ export default {
       type: String,
       default: null,
     },
+    isSortIconAlwaysVisible: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data: () => ({
@@ -64,7 +68,7 @@ export default {
     },
 
     showSortIcon() {
-      return this.isSortable && this.order && this.isSortedKey
+      return (this.isSortable && this.order && this.isSortedKey) || this.isSortIconAlwaysVisible
     },
 
     sortKey() {

--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -264,6 +264,7 @@ const SbDataTable = {
                   selectedRows: this.hasSelectedRowsInList,
                   selectionMode: this.selectionMode,
                   sortedKey: this.sortKey,
+                  isSortIconAlwaysVisible: this.isSortIconAlwaysVisible,
                 },
               })
             : null,
@@ -288,6 +289,7 @@ const SbDataTable = {
                         selectedRows: this.hasSelectedRowsInList,
                         selectionMode: this.selectionMode,
                         sortedKey: this.sortKey,
+                        isSortIconAlwaysVisible: this.isSortIconAlwaysVisible,
                       },
                     })
                   : null,

--- a/src/components/DataTable/sharedProps.js
+++ b/src/components/DataTable/sharedProps.js
@@ -57,4 +57,8 @@ export default {
     type: Boolean,
     default: false,
   },
+  isSortIconAlwaysVisible: {
+    type: Boolean,
+    default: false,
+  },
 }


### PR DESCRIPTION


<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [ON-894](https://storyblok.atlassian.net/browse/ON-894)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

- Try to set the `isSortIconAlwaysVisible` to `true` and check if the icon is displayed

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- There is now a new `prop` to make the caret icon always visible in table headers

## Other information
