### PR TITLE
fix(work-723): sbGroupButton fix component update when changing props

### DIFF
--- a/src/components/Accordion/SbAccordion.vue
+++ b/src/components/Accordion/SbAccordion.vue
@@ -80,7 +80,7 @@ export default {
     },
   },
 
-  emits: ['icon-click'],
+  emits: ['icon-click', 'toggle-open'],
   setup(props, { emit }) {
     const isOpenLocal = ref(props.isOpen)
     const chevronIcon = computed(() =>

--- a/src/components/AvatarGroup/SbAvatarGroup.vue
+++ b/src/components/AvatarGroup/SbAvatarGroup.vue
@@ -46,7 +46,7 @@ export default {
     },
   },
 
-  emits: ['click'],
+  emits: ['click', 'toggle-visible-dropdown'],
 
   data() {
     return {

--- a/src/components/AvatarGroup/components/SbMoreAvatars.vue
+++ b/src/components/AvatarGroup/components/SbMoreAvatars.vue
@@ -50,7 +50,7 @@ export default {
     },
   },
 
-  emits: ['click'],
+  emits: ['click', 'toggle-avatars-dropdown'],
 
   data() {
     return {

--- a/src/components/Breadcrumbs/BreadcrumbItem.vue
+++ b/src/components/Breadcrumbs/BreadcrumbItem.vue
@@ -58,7 +58,10 @@ export default {
       type: String,
       default: null,
     },
-    to: [String, Object],
+    to: {
+      type: [String, Object],
+      default: null,
+    },
     replace: Boolean,
   },
 

--- a/src/components/Breadcrumbs/BreadcrumbLink.vue
+++ b/src/components/Breadcrumbs/BreadcrumbLink.vue
@@ -17,15 +17,30 @@ export default {
       type: String,
       default: null,
     },
-    title: String,
-    target: String,
+    title: {
+      type: String,
+      default: '',
+    },
+    target: {
+      type: String,
+      default: '',
+    },
     append: Boolean,
     disabled: Boolean,
     exact: Boolean,
-    exactActiveClass: String,
+    exactActiveClass: {
+      type: String,
+      default: '',
+    },
     link: Boolean,
-    href: String,
-    to: [String, Object],
+    href: {
+      type: String,
+      default: '',
+    },
+    to: {
+      type: [String, Object],
+      default: null,
+    },
     replace: Boolean,
   },
 

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -61,7 +61,7 @@
         :min-date="minDate"
         :max-date="maxDate"
         :disabled-past="disabledPast"
-        @update:modelValue="handleComponentsInput"
+        @update:model-value="handleComponentsInput"
         @input-minutes="handleMinutesInput"
       />
 

--- a/src/components/GroupButton/SbGroupButton.vue
+++ b/src/components/GroupButton/SbGroupButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="sb-group-button" :class="activeClasses" v-bind="$attrs">
-    <VNodes :vnodes="activeSlots" />
+    <VNodes :vnodes="activeSlots()" />
   </div>
 </template>
 
@@ -25,9 +25,11 @@ export default {
         'sb-group-button--has-spaces': this.hasSpaces,
       }
     },
+  },
+  methods: {
     activeSlots() {
       const children = this.$slots.default && this.$slots.default()
-      const chilrenWithProps = children
+      return children
         .filter((b) => b.__v_isVNode)
         .map((button) => {
           button.props = {
@@ -36,8 +38,6 @@ export default {
           }
           return button
         })
-
-      return chilrenWithProps
     },
   },
 }

--- a/src/components/GroupButton/group-button.scss
+++ b/src/components/GroupButton/group-button.scss
@@ -13,7 +13,7 @@
 
   &:not(&--has-spaces) {
     .sb-button {
-      margin: -1px;
+      margin: 0;
       border-radius: 0;
     }
 

--- a/src/components/GroupButton/group-button.scss
+++ b/src/components/GroupButton/group-button.scss
@@ -13,6 +13,7 @@
 
   &:not(&--has-spaces) {
     .sb-button {
+      margin: -1px;
       border-radius: 0;
     }
 


### PR DESCRIPTION
while I was using the SbGroupButton two problems were found

1. There’s a space between the buttons on safari

![sb-group-button](https://user-images.githubusercontent.com/7618411/209816122-d1c3e587-33de-46c4-8a56-ba1c3a7d3028.png)

2. The buttons are not updated when the button's text changes

https://user-images.githubusercontent.com/7618411/209816169-6a6b5c1c-4fea-479c-9d46-69de6edbd415.mov


## Pull request type

Jira Link: [WORK-723](https://storyblok.atlassian.net/browse/WORK-723)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Must not show a space(unless the `hasSpaces` is set to true)
- Must re-render the button if some prop change

## Other information


[WORK-723]: https://storyblok.atlassian.net/browse/WORK-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WORK-723]: https://storyblok.atlassian.net/browse/WORK-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ