### PR TITLE
Subtask(work-814): Send the disabled attribute in SbModal to SbPortal

### DIFF
--- a/src/components/Modal/SbModal.stories.js
+++ b/src/components/Modal/SbModal.stories.js
@@ -469,3 +469,41 @@ ModalCloseOnHeader.args = {
   title: 'Main Title',
   align: 'left',
 }
+export const ModalTarget = (args, storyContext) => ({
+  mixins: [StoriesModalMixin(args, storyContext)],
+
+  components: {
+    SbModal,
+    SbModalHeader,
+    SbModalContent,
+  },
+
+  template: `
+  <div id="boxModal" style="width: 500px; height: 400px">
+    <SbButton
+      label="Open Modal!"
+      variant="primary"
+      @click="handleShowModal"
+      v-if="!showModal"
+      style="margin: 0 auto; display: flex; margin-top: 30%;"
+    />
+    <SbModal :is-open="showModal" v-on:hide="showModal = false" disabled-target-default="true" target="#boxModal" overlay-position="relative" >
+      <SbModalContent>
+        <div style="width: 100%;"><p style="text-align: left; margin: 0;">This modal opens inside the div with id "boxModal"</p></div>
+      </SbModalContent>
+    </SbModal>
+  </div>`,
+})
+
+ModalTarget.parameters = {
+  docs: {
+    description: {
+      story: `This storie is to show that we can also render the modal inside any div, and not necessarily in the body of the document. 
+      For that we need to pass the 'target' and 'disabled-target-default' props.`,
+    },
+  },
+}
+
+ModalTarget.args = {
+  disabledTargetDefault: true,
+}

--- a/src/components/Modal/SbModal.vue
+++ b/src/components/Modal/SbModal.vue
@@ -6,6 +6,7 @@
     unmount-on-destroy
     target-slim
     :target="modalTarget"
+    :disabled="disabledTargetDefault"
   >
     <SbBlokUi v-if="open" :style="computedBlokUiStyle" @mousedown="wrapClose">
       <div
@@ -66,6 +67,7 @@ export default {
       type: String,
       default: () => `#sb-modal-target-${randomString(4)}`,
     },
+    disabledTargetDefault: Boolean,
     overlayPosition: {
       type: String,
       default: 'fixed',

--- a/src/components/Modal/__tests__/ModalPlugin.spec.js
+++ b/src/components/Modal/__tests__/ModalPlugin.spec.js
@@ -25,6 +25,7 @@ describe('Tests for ModalPlugin', () => {
   it('Test if ModalPlugin renderer correctly', async () => {
     const propsReference = {
       modalTarget: null,
+      disabledTargetDefault: null,
       title: 'Delete This Project',
       icon: null,
       align: null,

--- a/src/components/Modal/plugin/ModalPlugin.vue
+++ b/src/components/Modal/plugin/ModalPlugin.vue
@@ -25,6 +25,11 @@ export default {
       default: null,
     },
 
+    disabledTargetDefault: {
+      type: Boolean,
+      default: null,
+    },
+
     // modal-header
     align: {
       type: String,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
SbPortal uses <Teleport> from Vue 3, this feature has 'disable' attribute to disable default rendering of Teleport in document body.

Therefore, when executing the WORK-814 task, we saw the need to pass the dibabled attribute from SBModal to SbPortal, since we want the delete modal of discussions to be inside the comments box.

## Pull request type

Jira Link: [WORK-814](https://storyblok.atlassian.net/browse/WORK-814)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Go to Menu > SbModal > Modal Target >check if the modal is opening inside the div.


[WORK-814]: https://storyblok.atlassian.net/browse/WORK-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ