### PR TITLE
feat(AR-61): 💄 adds redirection to spaces list logic on header logo click

### DIFF
--- a/src/components/Sidebar/Sidebar.stories.js
+++ b/src/components/Sidebar/Sidebar.stories.js
@@ -46,7 +46,7 @@ const SidebarTemplate = (args) => ({
   },
 
   setup() {
-    return { args }
+    return { ...args }
   },
 
   data: () => ({
@@ -73,6 +73,7 @@ const SidebarTemplate = (args) => ({
     <SbSidebar
       v-bind="{ listItems }"
       :logo="logo"
+      :logo-destination-url="logoDestinationUrl"
       :minimize.sync="internalMinimize"
       :max-width="maxWidth"
     >
@@ -142,6 +143,7 @@ export default {
     listItems: [...listItemsData],
     minimize: false,
     logo: '',
+    logoDestinationUrl: null,
     maxWidth: null,
   },
   argTypes: {
@@ -158,6 +160,13 @@ export default {
       description: 'Adds a custom logo (with a url to an image) to the sidebar',
       control: {
         type: 'string',
+      },
+    },
+    logoDestinationUrl: {
+      name: 'logoDestinationUrl',
+      description: 'Optional redirection URL on click on the custom logo',
+      control: {
+        type: 'object',
       },
     },
   },
@@ -197,6 +206,23 @@ MaxWidth.parameters = {
     description: {
       story:
         'When setting the `maxWidth` value, the sidebar will automatically collapse/expand when the window width is equal or lower than and greater than.',
+    },
+  },
+}
+
+export const LogoDestinationUrl = SidebarTemplate.bind({})
+
+LogoDestinationUrl.args = {
+  logoDestinationUrl: {
+    name: 'https://www.storyblok.com/',
+  },
+}
+
+LogoDestinationUrl.parameters = {
+  docs: {
+    description: {
+      story:
+        'When setting the `logoDestinationUrl` value, the sidebar logo will automatically be wrapped in a `<SbLink/>` component.',
     },
   },
 }

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -15,10 +15,9 @@
 
       <div class="sb-sidebar__mobile-logo" @click="closeSidebar">
         <SbLink
+          v-if="logoDestinationUrl"
           as="router-link"
-          :to="{
-            name: 'ListSpacesRoute',
-          }"
+          :to="logoDestinationUrl"
         >
           <img
             v-if="logo"
@@ -28,6 +27,15 @@
           />
           <SbSidebarLogo v-else variant="dark" />
         </SbLink>
+        <template v-else>
+          <img
+            v-if="logo"
+            class="sb-custom-logo"
+            :src="logo"
+            alt="Custom Sidebar Logo"
+          />
+          <SbSidebarLogo v-else variant="dark" />
+        </template>
       </div>
     </div>
 
@@ -107,6 +115,12 @@ export default {
       type: String,
       default: '1000px',
       required: false,
+    },
+    logoDestinationUrl: {
+      type: Object,
+      validator(value) {
+        return value.hasOwnProperty('name')
+      },
     },
   },
 

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -82,6 +82,7 @@ import {
   SbSidebarListItem,
   SbSidebarToggle,
 } from './components'
+import SbLink from '../Link/SbLink'
 
 export default {
   name: 'SbSidebar',
@@ -92,6 +93,7 @@ export default {
     SbSidebarLogo,
     SbSidebarListItem,
     SbSidebarToggle,
+    SbLink,
   },
 
   directives: {

--- a/src/components/Sidebar/Sidebar.vue
+++ b/src/components/Sidebar/Sidebar.vue
@@ -14,13 +14,20 @@
       </div>
 
       <div class="sb-sidebar__mobile-logo" @click="closeSidebar">
-        <img
-          v-if="logo"
-          class="sb-custom-logo"
-          :src="logo"
-          alt="Custom Sidebar Logo"
-        />
-        <SbSidebarLogo v-else variant="dark" />
+        <SbLink
+          as="router-link"
+          :to="{
+            name: 'ListSpacesRoute',
+          }"
+        >
+          <img
+            v-if="logo"
+            class="sb-custom-logo"
+            :src="logo"
+            alt="Custom Sidebar Logo"
+          />
+          <SbSidebarLogo v-else variant="dark" />
+        </SbLink>
       </div>
     </div>
 

--- a/src/components/Sidebar/components/ListItem.vue
+++ b/src/components/Sidebar/components/ListItem.vue
@@ -5,7 +5,7 @@
     :aria-label="ariaLabelText"
     :aria-current="active && active + ''"
   >
-    <router-link
+    <SbLink
       v-if="isRouterLink"
       class="sb-sidebar-link"
       :class="computedLinkClasses"
@@ -25,7 +25,7 @@
         :label="label"
         :image="image"
       />
-    </router-link>
+    </SbLink>
     <component
       :is="as"
       v-else
@@ -54,11 +54,13 @@
 
 <script>
 import ListItemInner from './ListItemInner.vue'
+import SbLink from '../../Link/SbLink'
 
 export default {
   name: 'SbSidebarListItem',
 
   components: {
+    SbLink,
     ListItemInner,
   },
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [AR-61](https://storyblok.atlassian.net/browse/AR-61)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

https://user-images.githubusercontent.com/16685155/216122691-2e128fc0-da3f-4a23-9488-6574fa3588ea.mov

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The `<SbSidebar/>` component now receives a new **optional** `logoDestinationUrl` prop.

## Other information

This PR is linked to [another PR on the storyfront repo.](https://github.com/storyblok/storyfront/pull/3355)


[AR-61]: https://storyblok.atlassian.net/browse/AR-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ