### PR TITLE
Hotfix(ON-1003): send native value when set in checkbox

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.js
+++ b/src/components/Checkbox/Checkbox.stories.js
@@ -148,7 +148,7 @@ export const Outline = (args) => ({
     <div>
       <div>
         <SbCheckbox
-          name="radio-outline"
+          name="checkbox-outline"
           id="outline"
           label="Inactive"
           native-value="Inactive"
@@ -158,7 +158,7 @@ export const Outline = (args) => ({
         />
 
         <SbCheckbox
-          name="radio-outline"
+          name="checkbox-outline"
           id="outline-selected"
           label="Selected"
           native-value="Selected"
@@ -169,7 +169,7 @@ export const Outline = (args) => ({
         />
 
         <SbCheckbox
-          name="radio-outline"
+          name="checkbox-outline"
           id="outline-disabled"
           native-value="Disabled"
           label="Disabled"

--- a/src/components/Checkbox/SbCheckbox.vue
+++ b/src/components/Checkbox/SbCheckbox.vue
@@ -49,16 +49,14 @@ export default {
   inheritAttrs: false,
 
   props: {
-    label: {
-      type: String,
-      default: null,
-    },
     indeterminate: Boolean,
-    inline: Boolean,
-    outline: Boolean,
   },
 
-  emits: ['click'],
+  data() {
+    return {
+      checkboxElement: null,
+    }
+  },
 
   computed: {
     componentClasses() {
@@ -69,9 +67,19 @@ export default {
       ]
     },
   },
+
+  watch: {
+    internalValue(newValue) {
+      const typeOfValue = typeof this.nativeValue
+      const valueToEmit = typeOfValue.includes('string', 'number', 'boolean')
+        ? newValue
+        : this.checkboxElement.target.checked
+      this.$emit('update:modelValue', valueToEmit)
+    },
+  },
   methods: {
     handleInput(e) {
-      this.$emit('update:modelValue', e.target.checked)
+      this.checkboxElement = e
     },
   },
 }

--- a/src/components/Radio/SbRadio.vue
+++ b/src/components/Radio/SbRadio.vue
@@ -28,16 +28,6 @@ export default {
 
   inheritAttrs: false,
 
-  props: {
-    inline: Boolean,
-    outline: Boolean,
-
-    label: {
-      type: String,
-      default: null,
-    },
-  },
-
   computed: {
     componentClasses() {
       return [

--- a/src/mixins/checkbox-radio-mixin.js
+++ b/src/mixins/checkbox-radio-mixin.js
@@ -7,6 +7,12 @@ export default {
     disabled: Boolean,
     required: Boolean,
     name: String,
+    inline: Boolean,
+    outline: Boolean,
+    label: {
+      type: String,
+      default: null,
+    },
   },
 
   emits: ['update:modelValue'],


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [ON-1003](https://storyblok.atlassian.net/browse/ON-1003)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

After [these changes](https://github.com/storyblok/storyblok-design-system/commit/cbd3305f707d6a010567d5523b2e5c47b5e3b21d) were introduced, the component stopped sending the `native-value` when the checkbox is checked and currently it sends `true` when the box is checked or `false` when it's unchecked. This PR adds the possibility that when `native-value` is filled, this will be sent instead of `true`.

You can test this on the Space settings -> Users -> Edit some user:

Currently (the internalValue displays `true` or `false`):

https://user-images.githubusercontent.com/26799272/217312519-4ca13b3f-056e-4fb9-b058-ee84c7bc408d.mov

With this PR (the internalValue displays `['can_subscribe']` or `[]`):

https://user-images.githubusercontent.com/26799272/217312550-06e85642-0366-4e38-ac37-30c479a94332.mov

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- 
- 
- 

## Other information


