### PR TITLE
feat(ON-1004): :sparkles: updates users table sorting logic to consider pagination

### DIFF
--- a/src/components/DataTable/index.js
+++ b/src/components/DataTable/index.js
@@ -72,6 +72,20 @@ const SbDataTable = {
       }
       return this.items
     },
+
+    paginatedItemsList() {
+      if (this.pagination === null) {
+        return undefined
+      }
+      let paginatedItems = []
+      const items = [...this.sortedData]
+      const pageChunkIndex = this.pagination.currentPage - 1
+      while (items.length > 0) {
+        const pageChunk = items.splice(0, this.pagination.pageSize)
+        paginatedItems = [...paginatedItems, pageChunk]
+      }
+      return paginatedItems[pageChunkIndex]
+    },
   },
 
   watch: {
@@ -193,6 +207,9 @@ const SbDataTable = {
     const renderTable = () => {
       let headerData = []
       let bodyData = []
+      const items = this.paginatedItemsList
+        ? [...this.paginatedItemsList]
+        : [...this.sortedData]
 
       if (this.$slots.default && this.$slots.default()) {
         const children = this.$slots.default().filter((e) => e.type.name)
@@ -208,7 +225,7 @@ const SbDataTable = {
           }
         })
 
-        bodyData = this.sortedData.map((tableRow) => {
+        bodyData = items.map((tableRow) => {
           const columns = children.map((tableData) => {
             return h(
               SbDataTableColumn,

--- a/src/components/DataTable/sharedProps.js
+++ b/src/components/DataTable/sharedProps.js
@@ -61,4 +61,8 @@ export default {
     type: Boolean,
     default: false,
   },
+  pagination: {
+    type: Object,
+    default: null,
+  },
 }


### PR DESCRIPTION
This PR is about updating the users table sorting logic to consider pagination (used only in org team page)

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [ON-1004](https://storyblok.atlassian.net/browse/ON-1004)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

### Check that both the **sorting** and **pagination** logic works well on the organization users management page :
https://user-images.githubusercontent.com/16685155/222822270-615f1283-f1db-4ea7-abf8-9c78a28be642.mov

### Check that users table sorting logic still works on other pages :

- Space settings : 

https://user-images.githubusercontent.com/16685155/222822617-6942a8da-c534-4448-b3a4-ea3d4dcd64c9.mov


- Partner portal :

https://user-images.githubusercontent.com/16685155/222822585-e8f9cd0a-a7d3-43c4-b95b-a777cf8fb054.mov

<!-- Please describe how others can test this PR -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- On the organization team management page, the sorting logic now sorts the whole users list, not just the current page.

## Other information

This PR is linked [to another PR on the storyfront repo](https://github.com/storyblok/storyfront/pull/3514)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## For the reviewers

[Pull Request Checklist](https://www.notion.so/storyblok/Pull-Request-Checklist-caef66feee2f4ae3b898534c1e4c1275)

[ON-1004]: https://storyblok.atlassian.net/browse/ON-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ