### PR TITLE
feat(work-589): adding 'list-item' and 'selection' slots to the SbSelect component

### DIFF
--- a/src/components/Select/Select.stories.js
+++ b/src/components/Select/Select.stories.js
@@ -9,7 +9,9 @@ const SelectTemplate = (args) => ({
     SbSelect,
   },
 
-  props: Object.keys(args),
+  setup() {
+    return { ...args }
+  },
 
   data: () => ({
     internalValue: null,

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -40,6 +40,10 @@
       @clear-all-values="handleClearAllValues"
       @remove-item-value="handleRemoveItemValue"
     >
+      <template #selection="scope">
+        <slot name="selection" v-bind="scope" />
+      </template>
+
       <slot name="innerSelect" />
     </SbSelectInner>
 
@@ -73,7 +77,11 @@
       @emit-value="handleEmitValue"
       @option-created="handleOptionCreated"
       @focus-item="focusAtIndex($event)"
-    />
+    >
+      <template #list-item="scope">
+        <slot name="list-item" v-bind="scope" />
+      </template>
+    </SbSelectList>
 
     <slot name="minibrowser" />
 

--- a/src/components/Select/__tests__/Select.spec.js
+++ b/src/components/Select/__tests__/Select.spec.js
@@ -1053,4 +1053,69 @@ describe('SbSelect component', () => {
       })
     })
   })
+
+  describe('Show custom selection', () => {
+    const wrapper = mountAttachingComponent(SbSelect, {
+      props: {
+        label: 'Choose an option',
+        options: [...defaultSelectOptionsData],
+        modelValue: [1, 2, 3],
+        multiple: true,
+      },
+      slots: {
+        selection: `
+          <template #selection="{ item, remove }">
+            <span class="custom-selection" @click="remove">
+              label: {{ item.label }}, value: {{ item.value }}
+            </span>
+          </template>
+        `,
+      },
+    })
+
+    it('should render the selection slot for selected items', () => {
+      const customSelectionItems = wrapper.findAll('.custom-selection')
+      expect(customSelectionItems.length).toBe(3)
+    })
+
+    it('should pass the item in the scope', () => {
+      const customSelection = wrapper.find('.custom-selection')
+      expect(customSelection.text()).toBe('label: Option 1, value: 1')
+    })
+
+    it('should pass the remove function in the scope', async () => {
+      const customSelection = wrapper.find('.custom-selection')
+      await customSelection.trigger('click')
+      expect(wrapper.emitted('update:modelValue')[0]).toEqual([[2, 3]])
+    })
+  })
+
+  describe('Show custom list item', () => {
+    const wrapper = mountAttachingComponent(SbSelect, {
+      props: {
+        label: 'Choose an option',
+        options: [...defaultSelectOptionsData],
+        modelValue: null,
+      },
+      slots: {
+        'list-item': `
+          <template #list-item="{ item }">
+            <span class="custom-item">
+              Custom: {{ item.label }}
+            </span>
+          </template>
+        `,
+      },
+    })
+
+    it('should render the list-item slot for each item', () => {
+      const customItems = wrapper.findAll('.custom-item')
+      expect(customItems.length).toBe(7)
+    })
+
+    it('should pass the item in the scope', () => {
+      const customItem = wrapper.find('.custom-item')
+      expect(customItem.text()).toBe('Custom: Option 1')
+    })
+  })
 })

--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -14,30 +14,39 @@
     />
 
     <div v-if="isTagsVisible" class="sb-select-inner__tags">
-      <SbTag
-        v-for="(tagLabel, key) in tagLabels"
-        :key="key"
-        tabindex="0"
-        :closable="!isDisabled"
-        @keydown="handleTagKeydown($event, tagLabel)"
-        @close="removeItem($event, tagLabel)"
-      >
-        <template v-if="tagLabel">
-          <SbAvatar
-            v-if="isTagAvatarVisible"
-            :key="tagLabel[itemLabel]"
-            :src="getSource(tagLabel)"
-            size="small"
-            :name="tagLabel[itemLabel]"
-          />
-          <span class="sb-select-inner__tag" :title="getTagTitle(tagLabel)">
-            <template v-if="showCaption">
-              {{ tagLabel[itemLabel] }} ({{ tagLabel[itemCaption] }})
+      <div v-for="(tagLabel, key) in tagLabels" :key="key">
+        <slot
+          name="selection"
+          :item="tagLabel"
+          :remove="(e) => removeItem(e, tagLabel)"
+        >
+          <SbTag
+            tabindex="0"
+            :closable="!isDisabled"
+            @keydown="handleTagKeydown($event, tagLabel)"
+            @close="removeItem($event, tagLabel)"
+          >
+            <template v-if="tagLabel">
+              <SbAvatar
+                v-if="isTagAvatarVisible"
+                :key="tagLabel[itemLabel]"
+                :src="getSource(tagLabel)"
+                size="small"
+                :name="tagLabel[itemLabel]"
+              />
+              <span class="sb-select-inner__tag" :title="getTagTitle(tagLabel)">
+                <template v-if="showCaption">
+                  {{ tagLabel[itemLabel] }} ({{ tagLabel[itemCaption] }})
+                </template>
+                <template v-else>{{
+                  tagLabel[itemLabel] || tagLabel
+                }}</template>
+              </span>
             </template>
-            <template v-else>{{ tagLabel[itemLabel] || tagLabel }}</template>
-          </span>
-        </template>
-      </SbTag>
+          </SbTag>
+        </slot>
+      </div>
+
       <input
         v-if="filterable"
         :id="inputId"

--- a/src/components/Select/components/SelectList.vue
+++ b/src/components/Select/components/SelectList.vue
@@ -23,7 +23,11 @@
           :selected="shouldBeChecked(index)"
           @emit-value="handleEmitValue"
           @mouseenter="handleFocusItem(index)"
-        />
+        >
+          <template #list-item="scope">
+            <slot name="list-item" v-bind="scope" />
+          </template>
+        </SbSelectListItem>
       </template>
       <li
         v-if="showTagCreation"

--- a/src/components/Select/components/SelectListItem.vue
+++ b/src/components/Select/components/SelectListItem.vue
@@ -19,20 +19,22 @@
     <template v-else>
       <SbCheckbox v-if="multiple" :model-value="isSelected" />
 
-      <span class="sb-select-list__item-icon">
-        <SbIcon v-if="option.icon" :name="option.icon" />
-      </span>
+      <slot name="list-item" :item="option">
+        <span class="sb-select-list__item-icon">
+          <SbIcon v-if="option.icon" :name="option.icon" />
+        </span>
 
-      <span v-if="!showCaption" class="sb-select-list__item-name">{{
-        label
-      }}</span>
-
-      <div v-else class="sb-select-list__item--with-path">
-        <span class="sb-select-list__item-name">{{ label }}</span>
-        <span v-if="showCaption" class="sb-select-list__item-caption">{{
-          path
+        <span v-if="!showCaption" class="sb-select-list__item-name">{{
+          label
         }}</span>
-      </div>
+
+        <div v-else class="sb-select-list__item--with-path">
+          <span class="sb-select-list__item-name">{{ label }}</span>
+          <span v-if="showCaption" class="sb-select-list__item-caption">{{
+            path
+          }}</span>
+        </div>
+      </slot>
     </template>
   </li>
 </template>


### PR DESCRIPTION
I added two new slots to the SbSelect component to help implement this behavior [Allowed-list-for-the-content-type-from-a-folder](https://www.figma.com/file/NWShEZSLMgkvKdNGwmBk4W/%5BWORK-635%5D-Allowed-list-for-the-content-type-from-a-folder?node-id=367-26046&t=OmqStiTS5NUhS6Dk-0)


https://user-images.githubusercontent.com/7618411/226925833-054499fd-9c3c-4911-abe5-5a546273d996.mov




It must not affect the way SbSelect is used now and should not have side effects, only add the possibility to pass custom selected items and custom items for the list.

## Pull request type

Jira Link: [WORK-589](https://storyblok.atlassian.net/browse/WORK-589)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- It should behave as before, only new slots were added

## Other information


[WORK-589]: https://storyblok.atlassian.net/browse/WORK-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ