### PR TITLE
feat(str-1630): fix flex issue and add example content info

### DIFF
--- a/src/components/Accordion/Accordion.stories.js
+++ b/src/components/Accordion/Accordion.stories.js
@@ -5,12 +5,13 @@ export default {
   component: Accordion,
   args: {
     title: 'Group 1',
-    icon: '',
+    icon: 'settings',
     iconDescription: '',
     isOpen: false,
     noHighlight: false,
     noBorder: false,
     noPadding: false,
+    contentInfoSlot: '<i>4 items</i>',
   },
 }
 
@@ -90,7 +91,7 @@ noPadding.args = {
   noPadding: true,
 }
 
-export const withContentInfo = Template.bind({})
-withContentInfo.args = {
-  contentInfoSlot: '4 items',
+export const contentInfo = Template.bind({})
+contentInfo.args = {
+  contentInfoSlot: '',
 }

--- a/src/components/Accordion/accordion.scss
+++ b/src/components/Accordion/accordion.scss
@@ -14,6 +14,7 @@
 }
 
 .sb-accordion__title {
+  flex: 1;
   overflow: hidden;
   max-width: 80%;
   margin-left: 2px;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [STR-1630](https://storyblok.atlassian.net/browse/STR-1630)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

This fixes an issue with the flex layout when the icon is present
Also, now an example of the content info will show by default in Storybook

Before and After example
![Screenshot 2023-03-28 at 20 44 05](https://user-images.githubusercontent.com/86601249/228340364-1c9c90f2-4045-4138-948a-dae1b8e468af.png)
![Screenshot 2023-03-28 at 20 45 05](https://user-images.githubusercontent.com/86601249/228340375-f1041be7-1b74-4426-86b0-cd2a75f1bbd3.png)


## Other information


[STR-1630]: https://storyblok.atlassian.net/browse/STR-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ