### PR TITLE
refactor(str-1689): ♻️ make button a simple button

### DIFF
--- a/src/components/Accordion/SbAccordion.vue
+++ b/src/components/Accordion/SbAccordion.vue
@@ -2,6 +2,7 @@
   <div class="sb-accordion" :class="activeClasses">
     <button
       class="sb-accordion__button"
+      type="button"
       :aria-expanded="isOpenLocal"
       :aria-controls="`collapse${title}`"
       @click="toggleAccordion"


### PR DESCRIPTION
## Pull request type


Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

- [ ] Nothing should change, should work as begore

## What is the new behavior?

This PR set the type of the button to "button" so it won't trigger submit when used inside a form

## Other information

To see the problem in action without the 'button' type specification you can go here: https://github.com/storyblok/storyfront/pull/3654 and test in the develop env: Space > Settings > Webhook > New webhook.
Write in a field and press enter: it will toggle the accordion because these accordion button act as submit as the slideover is wrapped inside a form element
