### PR TITLE
bugfix(work-1021): remove parentheses in SbSelectInner

### DIFF
--- a/src/components/Select/Select.stories.js
+++ b/src/components/Select/Select.stories.js
@@ -130,7 +130,7 @@ export const defaultOptionsWithCaptionData = [
   },
   {
     label: 'Option 3',
-    caption: 'uk/folder-text/uk',
+    caption: '',
     value: 3,
   },
   {
@@ -613,6 +613,23 @@ WithCaption.parameters = {
     description: {
       story:
         'When we pass the `showCaption` prop, it will be possible to render a caption below the name of the value in the `SbSelectList` and in the `SelectInner`, in addition to the value, the caption will be shown in parentheses, the name of the key in the object that will bring the values of the caption can have any name, by default it is `caption` but you can pass any customizable name through the `itemCaption` prop.',
+    },
+  },
+}
+
+export const WithCaptionTag = SelectTemplate.bind({})
+
+WithCaptionTag.args = {
+  showCaption: true,
+  multiple: true,
+  options: [...defaultOptionsWithCaptionData],
+}
+
+WithCaptionTag.parameters = {
+  docs: {
+    description: {
+      story:
+        'When we pass the `multiple` and `showCaption` prop, it will be possible to render a caption below the name of the value in the `SbSelectList` and in the `SelectInner`, in addition to the value, the caption will be shown in parentheses, the name of the key in the object that will bring the values of the caption can have any name, by default it is `caption` but you can pass any customizable name through the `itemCaption` prop.',
     },
   },
 }

--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -395,7 +395,7 @@ export default {
     modelValue(val, oldVal) {
       const isSameValue = JSON.stringify(val) === JSON.stringify(oldVal)
       if (this.isSearchTextVisible && !isSameValue) {
-        if (oldVal.length && val.length) {
+        if (oldVal?.length && val?.length) {
           this.$nextTick(() => this.$refs.search.focus())
         }
         return

--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -36,7 +36,7 @@
               />
               <span class="sb-select-inner__tag" :title="getTagTitle(tagLabel)">
                 <template v-if="showCaption">
-                  {{ tagLabel[itemLabel] }} ({{ tagLabel[itemCaption] }})
+                  {{ tagLabel[itemLabel] }} <span v-if="tagLabel[itemCaption]">({{ tagLabel[itemCaption] }})</span>
                 </template>
                 <template v-else>{{
                   tagLabel[itemLabel] || tagLabel
@@ -395,7 +395,7 @@ export default {
     modelValue(val, oldVal) {
       const isSameValue = JSON.stringify(val) === JSON.stringify(oldVal)
       if (this.isSearchTextVisible && !isSameValue) {
-        if (oldVal?.length && val?.length) {
+        if (oldVal.length && val.length) {
           this.$nextTick(() => this.$refs.search.focus())
         }
         return

--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -255,9 +255,9 @@ export default {
       }
 
       if (this.showCaption && this.currentOptionValue) {
-        return `${this.currentOptionLabel} (${
-          this.currentOptionValue[this.itemCaption]
-        })`
+        return this.currentOptionValue[this.itemCaption] ? `${this.currentOptionLabel} (${
+          this.currentOptionValue[this.itemCaption]})` : 
+          `${this.currentOptionLabel}`
       }
 
       if (this.inline) {
@@ -529,7 +529,7 @@ export default {
 
       if (this.showCaption) {
         const caption = tagLabel[this.itemCaption]
-        return `${label} (${caption})`
+        return caption ? `${label} (${caption})` : `${label}`
       }
 
       return label

--- a/src/components/Select/select.scss
+++ b/src/components/Select/select.scss
@@ -251,6 +251,9 @@
 }
 
 .sb-select-list {
+  @include popoverComponent();
+  @include listPosition();
+  
   display: none;
   flex: 1;
   overflow: auto;
@@ -260,9 +263,6 @@
   min-width: 176px;
   padding: 13px 0;
   background-color: $white;
-
-  @include popoverComponent();
-  @include listPosition();
 
   ul {
     margin: 0;


### PR DESCRIPTION
When we pass the showCaption prop, if the item does not have an itemCaption, the system is displaying empty parentheses:
![image](https://user-images.githubusercontent.com/8209305/231547171-e080eeeb-7aed-4ac2-9141-b766f10d2af4.png)


## Pull request type

Jira Link: [IWORK-1021](https://storyblok.atlassian.net/browse/WORK-1021)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
Go to: Form > SbSelect > With Caption Tag
Select item 3, it will not have a caption. Make sure parentheses are not displayed.

Go to: Form > SbSelect > With Caption
Select item 3, it will not have a caption. Make sure parentheses are not displayed.

