### PR TITLE
style(work-810): improving table action bar on small devices

### DIFF
--- a/src/components/DataTable/data-table.scss
+++ b/src/components/DataTable/data-table.scss
@@ -157,12 +157,21 @@
   color: $white;
   background-color: $sb-dark-blue;
   border-radius: 5px;
+  flex-wrap: wrap;
+
+  @include mq($until: sm) {
+    padding: 0 11px 0 2px;
+  }
 
   &__rows-selected {
     margin-left: 0;
     color: $white;
     font-family: $primary-font-family;
     font-size: 14px;
+
+    @include mq($until: sm) {
+      display: none;
+    }
   }
 
   &__btn:focus {
@@ -170,7 +179,11 @@
   }
 
   &__btn {
-    margin-left: 10px;
+    margin-left: 2px;
+
+    @include mq($from: sm) {
+      margin-left: 10px;
+    }
   }
 
   &__btn-cancel {


### PR DESCRIPTION
Make the table's action bar looks good on mobile devices

## Pull request type

Jira Link: [WORK-810](https://storyblok.atlassian.net/browse/WORK-810)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Go to [SbDataTable](https://storyblok-design-system-git-chore-work-810-71beb5-storyblok-com.vercel.app/?path=/story/data-sbdatatable--actions-menu) and make sure the action bar looks good in both mobile and desktop

*Before*
<img width="434" alt="Screenshot 2023-04-26 at 12 17 33" src="https://user-images.githubusercontent.com/7618411/234622282-ca69746f-7644-4858-af13-89a02223e1e3.png">

*With this changes* 
<img width="451" alt="Screenshot 2023-04-26 at 12 18 06" src="https://user-images.githubusercontent.com/7618411/234622432-5411538a-74f0-49dc-b35c-f757b756d304.png">


## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- 

## Other information


[WORK-810]: https://storyblok.atlassian.net/browse/WORK-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ