### PR TITLE
feat(STR-1654): Create preventEnterOnSearch prop in Minibrowser component

### DIFF
--- a/src/components/Minibrowser/Minibrowser.vue
+++ b/src/components/Minibrowser/Minibrowser.vue
@@ -120,6 +120,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    preventEnterOnSearch: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   emits: ['clear-navigation', 'close', 'filter', 'navigate', 'select-item'],
@@ -215,7 +219,7 @@ export default {
     handleSearchKeydown(event) {
       if (event.key === 'Escape') {
         this.$emit('close')
-      } else if (event.key === 'Enter') {
+      } else if (event.key === 'Enter' && !this.preventEnterOnSearch) {
         this.selectFilteredItem()
       }
     },

--- a/src/components/Minibrowser/__tests__/Minibrowser.spec.js
+++ b/src/components/Minibrowser/__tests__/Minibrowser.spec.js
@@ -107,6 +107,71 @@ describe('SbMinibrowser component', () => {
     ])
   })
 
+  it('should emit the single selected element when press enter in the search input', async () => {
+    const wrapper = mount(SbMinibrowser, {
+      props: {
+        options: [...MOCK_DATA.FIRST_LEVEL],
+      },
+    })
+
+    const jobsItem = {
+      label: 'Jobs',
+      subtitle: 'jobs',
+      value: '1.2',
+    }
+
+    const searchInput = wrapper.find('input[type="search"]')
+
+    await searchInput.setValue('Jobs')
+
+    await wrapper.vm.$nextTick()
+
+    await waitMs(300)
+
+    await wrapper.setProps({
+      options: [jobsItem],
+    })
+
+    await searchInput.trigger('keydown', {
+      key: 'Enter',
+    })
+
+    expect(wrapper.emitted('select-item')[0]).toEqual([jobsItem])
+  })
+
+  it('should do not emit the single selected element when press enter in the search input if the preventEnterOnSearch is true', async () => {
+    const wrapper = mount(SbMinibrowser, {
+      props: {
+        options: [...MOCK_DATA.FIRST_LEVEL],
+        preventEnterOnSearch: true,
+      },
+    })
+
+    const jobsItem = {
+      label: 'Jobs',
+      subtitle: 'jobs',
+      value: '1.2',
+    }
+
+    const searchInput = wrapper.find('input[type="search"]')
+
+    await searchInput.setValue('Jobs')
+
+    await wrapper.vm.$nextTick()
+
+    await waitMs(300)
+
+    await wrapper.setProps({
+      options: [jobsItem],
+    })
+
+    await searchInput.trigger('keydown', {
+      key: 'Enter',
+    })
+
+    expect(wrapper.emitted('select-item')).toBeUndefined()
+  })
+
   it('should clear the search input when an item is clicked', async () => {
     const wrapper = mount(SbMinibrowser, {
       props: {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [STR-1654](https://storyblok.atlassian.net/browse/STR-1654)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

Check if the SbMinibrowser component works as expected. This PR only adds a prop to prevent the key down enter logic in the minibrowser search that selects the only filtered element.

[STR-1654]: https://storyblok.atlassian.net/browse/STR-1654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ