### PR TITLE
hotfix(STR-1756): force back the overflow auto in the body element when unmounting the SbModal component

### DIFF
--- a/src/components/Modal/SbModal.vue
+++ b/src/components/Modal/SbModal.vue
@@ -140,6 +140,12 @@ export default {
     this.$_createPortalInstance()
   },
 
+  beforeUnmount() {
+    if (document.querySelector) {
+      document.querySelector('body').style.overflow = 'auto'
+    }
+  },
+
   methods: {
     escapeEventListener(e) {
       if (e.key === 'Escape') {


### PR DESCRIPTION
This is because sometimes we use the SbModal with a conditional (v-if). With this, the auto overflow is not set because the component disappears from the DOM doing this, we can prevent the error that the scroll in the body keeps wrong after SbModal closing

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [STR-1756](https://storyblok.atlassian.net/browse/STR-1756)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

Check the SbModal component. Now, when we close the modal or remove the SbModal component from the Vue Component Tree, the overflow property in the `body` will turn out to auto.


[STR-1756]: https://storyblok.atlassian.net/browse/STR-1756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ