### PR TITLE
fix(work-1041): update input text disabled style to use class

### DIFF
--- a/src/components/TextField/SbTextField.vue
+++ b/src/components/TextField/SbTextField.vue
@@ -200,6 +200,7 @@ export default {
 
     hasSpecialClass() {
       return [
+        this.disabled && 'sb-textfield__input--disabled',
         this.error && 'sb-textfield__input--error',
         this.ghost && 'sb-textfield__input--ghost',
         !this.error && !this.ghost && 'sb-textfield__input--default',

--- a/src/components/TextField/textfield.scss
+++ b/src/components/TextField/textfield.scss
@@ -59,7 +59,7 @@
     border-radius: $base-border-radius;
     transition: $base-transition;
 
-    &:disabled {
+    &--disabled {
       background: $light-25;
       border: 1px solid $light !important;
       cursor: not-allowed;
@@ -136,7 +136,7 @@
     }
 
     &--error {
-      border: 1px solid $red;
+      border: 1px solid $red !important;
 
       &:focus {
         box-shadow: 0 0 0 3px rgb(255, 179, 176, 0.3);


### PR DESCRIPTION
**Related to https://github.com/storyblok/storyfront/pull/3952**
<!--- Please provide a general summary of your changes in the title above -->
<img width="931" alt="image" src="https://github.com/storyblok/storyblok-design-system/assets/4389464/a210c2ce-8a13-4677-b685-084667299d61">


## Pull request type

Jira Link: [WORK-1041](https://storyblok.atlassian.net/browse/WORK-1041)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
1. An easy easy to test it is within the context of this very same ticket (WORK-1041)
2. Make sure that, whenever you're adding a new language with the label "Default", the first default one will remain disabled but with red borders when errored

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Replacing the styling of disabled input to use class instead of the _disabled_ attribute, to make sure that when the input is disabled AND with error, the red border prevails

## Other information


[WORK-1041]: https://storyblok.atlassian.net/browse/WORK-1041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ