### PR TITLE
feat(str-1606): remove padding on mobile when in full width mode

### DIFF
--- a/src/components/BlockUI/BlockUi.vue
+++ b/src/components/BlockUI/BlockUi.vue
@@ -13,12 +13,17 @@ export default {
       type: Boolean,
       default: false,
     },
+    withMargin: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   computed: {
     computedClass() {
       return {
         'sb-block-ui--in-element': this.inElement,
+        'sb-block-ui--with-margin': this.withMargin,
       }
     },
   },

--- a/src/components/BlockUI/block.scss
+++ b/src/components/BlockUI/block.scss
@@ -12,11 +12,16 @@
   overflow-y: auto;
   box-sizing: border-box;
   width: 100%;
-  padding: 20px;
   background-color: $black-trasparent;
-}
 
-.sb-block-ui--in-element {
-  position: absolute;
-  background-color: transparent;
+  &--in-element {
+    position: absolute;
+    background-color: transparent;
+  }
+
+  &--with-margin {
+    @include mq($from: sm) {
+      padding: 20px;
+    }
+  }
 }

--- a/src/components/Modal/SbModal.vue
+++ b/src/components/Modal/SbModal.vue
@@ -8,7 +8,7 @@
     :target="modalTarget"
     :disabled="disabledTargetDefault"
   >
-    <SbBlokUi v-if="open" :style="computedBlokUiStyle" @mousedown="wrapClose">
+    <SbBlokUi v-if="open" :style="computedBlokUiStyle" :with-margin="fullWidth" @mousedown="wrapClose">
       <div
         ref="modal"
         class="sb-modal"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [STR-1606](https://storyblok.atlassian.net/browse/STR-1606)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

- [ ] Modal set as full width now are full page in mobile viewport

## What is the new behavior?

For this [task](https://storyblok.atlassian.net/browse/STR-1606) I needed to remove the padding on the modal in the mobile viewport, so I made the full width modal work without padding on mobile

## Other information


[STR-1606]: https://storyblok.atlassian.net/browse/STR-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ