### PR TITLE
feat(work-1090): adding an inline-label to SbSelect, SbDatepicker, an…

### DIFF
--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -24,6 +24,7 @@ const Template = (args) => ({
         :min-date="minDate"
         :max-date="maxDate"
         :disabled-past="disabledPast"
+        :inline-label="inlineLabel"
       />
     </div>
   `,
@@ -137,6 +138,18 @@ export default {
         type: 'boolean',
       },
     },
+    inlineLabel: {
+      name: 'inlineLabel',
+      description: 'Use the `inline-label` property to add text inside the field',
+      defaultValue: '',
+      table: {
+        type: { summary: 'String' },
+        defaultValue: { summary: '' },
+      },
+      control: {
+        type: 'text',
+      },
+    },
   },
 }
 
@@ -224,6 +237,20 @@ DisabledDatePast.parameters = {
     description: {
       story:
         'Add the `disabled-past` attribute to disabled select dates in past.',
+    },
+  },
+}
+
+export const WithInlineLabel = Template.bind({})
+
+WithInlineLabel.args = {
+  inlineLabel: 'Date:'
+}
+
+WithInlineLabel.parameters = {
+  docs: {
+    description: {
+      story: 'Use the `inline-label` property to add text inside the field',
     },
   },
 }

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -15,6 +15,7 @@
         :placeholder="placeholder"
         :model-value="internalValueFormatted"
         :error="invalidDate"
+        :inline-label="inlineLabel"
         clearable
         @icon-click="handleInputClick"
         @clear="handleClear"
@@ -180,6 +181,11 @@ export default {
     disabledPast: {
       type: Boolean,
       default: false,
+    },
+
+    inlineLabel: {
+      type: String,
+      default: '',
     },
   },
 

--- a/src/components/Datepicker/__tests__/Datepicker.spec.js
+++ b/src/components/Datepicker/__tests__/Datepicker.spec.js
@@ -96,4 +96,24 @@ describe('SbDatepicker component', () => {
       expect(document.querySelector('[role="tooltip"]')).toBe(null)
     })
   })
+
+  describe('Inline label', () => {
+    it('should render the inline label if present', () => {
+      const wrapper = factory({
+        inlineLabel: 'Inline label',
+      })
+
+      expect(
+        wrapper.find('.sb-textfield__inner-label').text()
+      ).toBe('Inline label')
+    })
+
+    it('should not render the inline label by default', () => {
+      const wrapper = factory()
+
+      expect(
+        wrapper.find('.sb-textfield__inner-label').exists()
+      ).toBe(false)
+    })
+  })
 })

--- a/src/components/Datepicker/datepicker.scss
+++ b/src/components/Datepicker/datepicker.scss
@@ -45,7 +45,8 @@
 .sb-datepicker {
   position: relative;
 
-  &--active .sb-textfield__input {
+  &--active .sb-textfield__input,
+  &--active .sb-textfield--inline-label .sb-textfield__inner {
     @include focusedTextField;
   }
 

--- a/src/components/Select/Select.stories.js
+++ b/src/components/Select/Select.stories.js
@@ -58,6 +58,7 @@ const SelectTemplate = (args) => ({
       :clearable="clearable"
       :show-caption="showCaption"
       :is-option-disabled="isOptionDisabled"
+      :inline-label="inlineLabel"
       v-model="internalValue"
       :first-value-is-all-value="firstValueIsAllValue"
       style="max-width: 300px"
@@ -645,6 +646,20 @@ WithOptionDisabled.parameters = {
     description: {
       story:
         'When we pass the `isOptionDisabled` prop, it will be possible to render a option disabled',
+    },
+  },
+}
+
+export const WithInlineLabel = SelectTemplate.bind({})
+
+WithInlineLabel.args = {
+  inlineLabel: 'Item:'
+}
+
+WithInlineLabel.parameters = {
+  docs: {
+    description: {
+      story: 'Use the `inline-label` property to add text inside the select',
     },
   },
 }

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -32,6 +32,7 @@
       :error="error"
       :show-caption="showCaption"
       :item-caption="itemCaption"
+      :inline-label="inlineLabel"
       @click="handleSelectInnerClick"
       @keydown-enter="handleKeyDownEnter"
       @search="handleSearchInput"
@@ -214,6 +215,10 @@ export default {
     isOptionDisabled: {
       type: Function,
       default: () => false,
+    },
+    inlineLabel: {
+      type: String,
+      default: '',
     },
   },
 

--- a/src/components/Select/__tests__/Select.spec.js
+++ b/src/components/Select/__tests__/Select.spec.js
@@ -1135,4 +1135,34 @@ describe('SbSelect component', () => {
       expect(wrapper.emitted('update:modelValue')).toBeUndefined()
     })
   })
+
+  describe('Inline label', () => {
+    const factory = (props = {}) => {
+      return mountAttachingComponent(SbSelect, {
+        props: {
+          label: 'Choose an option',
+          options: [...defaultSelectOptionsData],
+          ...props,
+        },
+      })
+    }
+
+    it('should render the inline label if present', () => {
+      const wrapper = factory({
+        inlineLabel: 'Inline label',
+      })
+
+      expect(
+        wrapper.find('.sb-select-inner__inline-label').text()
+      ).toBe('Inline label')
+    })
+
+    it('should not render the inline label by default', () => {
+      const wrapper = factory()
+
+      expect(
+        wrapper.find('.sb-select-inner__inline-label').exists()
+      ).toBe(false)
+    })
+  })
 })

--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -6,6 +6,13 @@
     v-bind="$attrs"
     @keydown="handleKeyDown"
   >
+    <span
+      v-if="inlineLabel"
+      class="sb-select-inner__inline-label"
+    >
+      {{ inlineLabel }}
+    </span>
+
     <SbIcon
       v-if="leftIcon"
       class="sb-select-inner__icon-left"
@@ -206,6 +213,10 @@ export default {
       type: String,
       default: 'path',
     },
+    inlineLabel: {
+      type: String,
+      default: '',
+    },
   },
 
   emits: [
@@ -261,7 +272,7 @@ export default {
 
       if (this.showCaption && this.currentOptionValue) {
         return this.currentOptionValue[this.itemCaption] ? `${this.currentOptionLabel} (${
-          this.currentOptionValue[this.itemCaption]})` : 
+          this.currentOptionValue[this.itemCaption]})` :
           `${this.currentOptionLabel}`
       }
 

--- a/src/components/Select/select.scss
+++ b/src/components/Select/select.scss
@@ -136,6 +136,12 @@
   }
 
   // elements
+  &__inline-label {
+    margin-right: $s-1;
+    font-size: $font-14;
+    font-weight: $font-medium;
+  }
+
   &__icon-left {
     margin-right: 10px;
   }

--- a/src/components/TextField/SbTextField.vue
+++ b/src/components/TextField/SbTextField.vue
@@ -1,13 +1,5 @@
 <template>
-  <div
-    class="sb-textfield"
-    :class="[
-      $attrs.class,
-      {
-        'sb-textfield--inline-label': !!inlineLabel
-      }
-    ]"
-  >
+  <div :class="textFieldClasses">
     <label v-if="label" :for="id" class="sb-textfield__label">
       {{ label }} <span v-if="required" class="sb-textfield__required">*</span>
     </label>
@@ -314,6 +306,16 @@ export default {
         ...this.$attrs,
         class: '',
       }
+    },
+    textFieldClasses() {
+      return [
+        this.$attrs.class,
+        {
+          'sb-textfield': true,
+          'sb-textfield--inline-label': !!this.inlineLabel,
+          'sb-textfield--error': this.error,
+        },
+      ]
     },
   },
 

--- a/src/components/TextField/SbTextField.vue
+++ b/src/components/TextField/SbTextField.vue
@@ -1,74 +1,78 @@
 <template>
-  <div class="sb-textfield" :class="$attrs.class">
+  <div
+    class="sb-textfield"
+    :class="[
+      $attrs.class,
+      {
+        'sb-textfield--inline-label': !!inlineLabel
+      }
+    ]"
+  >
     <label v-if="label" :for="id" class="sb-textfield__label">
       {{ label }} <span v-if="required" class="sb-textfield__required">*</span>
     </label>
     <div class="sb-textfield__inner">
       <span v-if="prefix" class="sb-textfield__prefix">{{ prefix }}</span>
-      <input
-        v-if="!isTextAreaType"
-        v-bind="inputAttrs"
-        :id="id"
-        ref="textfield"
-        v-model="computedValue"
-        v-maska="mask"
-        :type="internalType"
-        :placeholder="placeholder"
-        :name="name"
-        :readonly="readonly"
-        :class="componentClasses"
-        :required="required"
-        :disabled="disabled"
-        :maxlength="maxlength"
-        :minlength="minlength"
-        @focus="handleFocusInput"
-        @blur="handleBlurInput"
-        @keydown="handleKeyDownInput"
-        @keypress="handleKeyPressInput"
-        @keyup="handleKeyUpInput"
-      />
 
-      <textarea
-        v-else
-        :id="id"
-        ref="textfield"
-        v-model="computedValue"
-        v-bind="$attrs"
-        class="sb-textfield__textarea"
-        :placeholder="placeholder"
-        :name="name"
-        :readonly="readonly"
-        :class="componentClasses"
-        :required="required"
-        :disabled="disabled"
-        :cols="cols"
-        :rows="rows"
-        :wrap="wrap"
-        :maxlength="maxlength"
-        :minlength="minlength"
-        @focus="handleFocusInput"
-        @blur="handleBlurInput"
-        @keydown="handleKeyDownInput"
-        @keypress="handleKeyPressInput"
-        @keyup="handleKeyUpInput"
-      />
-
-      <SbIcon
-        v-if="iconLeft && type !== 'password' && !iconDescription"
-        :style="returnIconCustomColor"
-        :name="iconLeft"
-        class="sb-textfield__icon sb-textfield__icon--left"
-        :color="iconColor"
-        data-testid="sb-textfield-icon-click"
-        @click="handleIconClick"
-      />
-      <SbTooltip
-        v-if="iconLeft && type !== 'password' && iconDescription"
-        :label="iconDescription"
-        position="bottom"
+      <span
+        v-if="inlineLabel"
+        class="sb-textfield__inner-label"
+        @click="$refs.textfield.focus()"
       >
+        {{ inlineLabel }}
+      </span>
+
+      <div class="sb-textfield__inner-field">
+        <input
+          v-if="!isTextAreaType"
+          v-bind="inputAttrs"
+          :id="id"
+          ref="textfield"
+          v-model="computedValue"
+          v-maska="mask"
+          :type="internalType"
+          :placeholder="placeholder"
+          :name="name"
+          :readonly="readonly"
+          :class="componentClasses"
+          :required="required"
+          :disabled="disabled"
+          :maxlength="maxlength"
+          :minlength="minlength"
+          @focus="handleFocusInput"
+          @blur="handleBlurInput"
+          @keydown="handleKeyDownInput"
+          @keypress="handleKeyPressInput"
+          @keyup="handleKeyUpInput"
+        />
+
+        <textarea
+          v-else
+          :id="id"
+          ref="textfield"
+          v-model="computedValue"
+          v-bind="$attrs"
+          class="sb-textfield__textarea"
+          :placeholder="placeholder"
+          :name="name"
+          :readonly="readonly"
+          :class="componentClasses"
+          :required="required"
+          :disabled="disabled"
+          :cols="cols"
+          :rows="rows"
+          :wrap="wrap"
+          :maxlength="maxlength"
+          :minlength="minlength"
+          @focus="handleFocusInput"
+          @blur="handleBlurInput"
+          @keydown="handleKeyDownInput"
+          @keypress="handleKeyPressInput"
+          @keyup="handleKeyUpInput"
+        />
+
         <SbIcon
-          v-if="iconLeft && type !== 'password'"
+          v-if="iconLeft && type !== 'password' && !iconDescription"
           :style="returnIconCustomColor"
           :name="iconLeft"
           class="sb-textfield__icon sb-textfield__icon--left"
@@ -76,31 +80,47 @@
           data-testid="sb-textfield-icon-click"
           @click="handleIconClick"
         />
-      </SbTooltip>
-      <SbIcon
-        v-if="hasIconRight"
-        :name="iconRight"
-        class="sb-textfield__icon sb-textfield__icon--right"
-        :color="iconColor"
-        data-testid="sb-textfield-icon-click"
-        @click="handleIconClick"
-      />
-      <SbIcon
-        v-if="internalIconRight && type === 'password'"
-        :name="internalIconRight"
-        class="sb-textfield__icon sb-textfield__icon--right"
-        :color="iconColor"
-        data-testid="sb-textfield-icon-click"
-        @click="handleShowHidePassword"
-      />
-      <SbIcon
-        v-if="showClearIcon"
-        v-tooltip="{ label: 'Clear' }"
-        name="x-clear"
-        :class="computedClearIconClasses"
-        :color="iconColor"
-        @click="handleClearableClick"
-      />
+        <SbTooltip
+          v-if="iconLeft && type !== 'password' && iconDescription"
+          :label="iconDescription"
+          position="bottom"
+        >
+          <SbIcon
+            v-if="iconLeft && type !== 'password'"
+            :style="returnIconCustomColor"
+            :name="iconLeft"
+            class="sb-textfield__icon sb-textfield__icon--left"
+            :color="iconColor"
+            data-testid="sb-textfield-icon-click"
+            @click="handleIconClick"
+          />
+        </SbTooltip>
+        <SbIcon
+          v-if="hasIconRight"
+          :name="iconRight"
+          class="sb-textfield__icon sb-textfield__icon--right"
+          :color="iconColor"
+          data-testid="sb-textfield-icon-click"
+          @click="handleIconClick"
+        />
+        <SbIcon
+          v-if="internalIconRight && type === 'password'"
+          :name="internalIconRight"
+          class="sb-textfield__icon sb-textfield__icon--right"
+          :color="iconColor"
+          data-testid="sb-textfield-icon-click"
+          @click="handleShowHidePassword"
+        />
+        <SbIcon
+          v-if="showClearIcon"
+          v-tooltip="{ label: 'Clear' }"
+          name="x-clear"
+          :class="computedClearIconClasses"
+          :color="iconColor"
+          @click="handleClearableClick"
+        />
+      </div>
+
       <span v-if="suffix" class="sb-textfield__suffix">{{ suffix }}</span>
 
       <slot />
@@ -168,6 +188,10 @@ export default {
       default: '',
     },
     mask: {
+      type: String,
+      default: '',
+    },
+    inlineLabel: {
       type: String,
       default: '',
     },

--- a/src/components/TextField/TextField.stories.js
+++ b/src/components/TextField/TextField.stories.js
@@ -96,7 +96,7 @@ export const Default = (args) => ({
         :errorMessage="errorMessage"
         error
       /><br>
-      <SbTextFiel
+      <SbTextField
       :id="id"
       :name="name"
       label="With error but no icon"
@@ -108,7 +108,7 @@ export const Default = (args) => ({
       v-model="internalValue"
       :errorMessage="errorMessage"
       error
-    />
+    /><br>
       <SbTextField
         :id="id"
         :name="name"
@@ -135,23 +135,23 @@ export const Default = (args) => ({
       <SbTextField
         :id="id"
         :name="name"
-        :label="label"
-        :disabled="disabled"
-        :required="required"
-        :placeholder="placeholder"
-        :readonly="readonly"
-        :maxlength="maxlength"
-        v-model="internalValue"
-      /><br>
-      <SbTextField
-        :id="id"
-        :name="name"
         label="With max length"
         :disabled="disabled"
         :required="required"
         :placeholder="placeholder"
         :readonly="readonly"
         maxlength="200"
+        v-model="internalValue"
+      /><br>
+      <SbTextField
+        :id="id"
+        :name="name"
+        label="With inline label"
+        inline-label="User:"
+        :disabled="disabled"
+        :required="required"
+        :placeholder="placeholder"
+        :readonly="readonly"
         v-model="internalValue"
       /><br>
     </div>
@@ -400,6 +400,45 @@ withMask.parameters = {
     description: {
       story:
         'Use "#" for numbers (0-9), “S” for letter in any case (a-z,A-Z), “X” for number or letter (a-z,A-Z,0-9), “*” for repeat and “!” for optional (next character).',
+    },
+  },
+}
+
+export const withInlineLabel = (args) => ({
+  components: { SbTextField },
+  setup() {
+    return { ...args }
+  },
+  data: () => ({
+    internalValue: '',
+  }),
+  template: `
+    <div style="max-width: 300px">
+      <SbTextField
+        v-model="internalValue"
+        label="With inline label"
+        :name="name"
+        :id="id"
+        :disabled="disabled"
+        :required="required"
+        :placeholder="placeholder"
+        :readonly="readonly"
+        :mask="mask"
+        :inline-label="inlineLabel"
+        native-value="Boris Spassky"
+      />
+    </div>
+  `,
+})
+
+withInlineLabel.args = {
+  inlineLabel: 'Email:'
+}
+
+withInlineLabel.parameters = {
+  docs: {
+    description: {
+      story: 'Use the `inline-label` property to add text inside field',
     },
   },
 }

--- a/src/components/TextField/TextField.stories.js
+++ b/src/components/TextField/TextField.stories.js
@@ -423,7 +423,6 @@ export const withInlineLabel = (args) => ({
         :required="required"
         :placeholder="placeholder"
         :readonly="readonly"
-        :mask="mask"
         :inline-label="inlineLabel"
         native-value="Boris Spassky"
       />
@@ -432,7 +431,7 @@ export const withInlineLabel = (args) => ({
 })
 
 withInlineLabel.args = {
-  inlineLabel: 'Email:'
+  inlineLabel: 'Email:',
 }
 
 withInlineLabel.parameters = {

--- a/src/components/TextField/__tests__/TextField.spec.js
+++ b/src/components/TextField/__tests__/TextField.spec.js
@@ -138,6 +138,24 @@ describe('SbTextField component', () => {
 
     expect(wrapper.find('.sb-textfield__counter').exists()).toBe(false)
   })
+
+  it('should render the inline label if present', () => {
+    const wrapper = factory({
+      inlineLabel: 'Inline label',
+    })
+
+    expect(
+      wrapper.find('.sb-textfield__inner-label').text()
+    ).toBe('Inline label')
+  })
+
+  it('should not render the inline label by default', () => {
+    const wrapper = factory()
+
+    expect(
+      wrapper.find('.sb-textfield__inner-label').exists()
+    ).toBe(false)
+  })
 })
 
 describe('SbTextField as textarea', () => {

--- a/src/components/TextField/textfield.scss
+++ b/src/components/TextField/textfield.scss
@@ -1,6 +1,22 @@
 .sb-textfield {
   width: 100%;
 
+  &--error {
+    &.sb-textfield--inline-label .sb-textfield__inner {
+      border: 1px solid $red;
+
+      &:hover,
+      &:focus,
+      &:focus-within {
+        border-color: $red;
+      }
+
+      &:focus-within {
+        box-shadow: 0 0 0 3px rgb(255, 179, 176, 0.3);
+      }
+    }
+  }
+
   &--inline-label {
     .sb-textfield__inner {
       align-items: stretch;
@@ -30,7 +46,7 @@
 
     .sb-textfield__input {
       padding-left: 0;
-      border: 0;
+      border: 0 !important;
       box-shadow: none !important;
 
       &--with-icon-left {

--- a/src/components/TextField/textfield.scss
+++ b/src/components/TextField/textfield.scss
@@ -1,6 +1,49 @@
 .sb-textfield {
   width: 100%;
 
+  &--inline-label {
+    .sb-textfield__inner {
+      align-items: stretch;
+      box-sizing: border-box;
+      background: $white;
+      border: 1px solid $light;
+      border-radius: $base-border-radius;
+
+      &:hover,
+      &:focus {
+        border-color: $sb-green;
+      }
+
+      &:focus-within {
+        @include focusedTextField;
+      }
+    }
+
+    .sb-textfield__inner-label {
+      padding-left: 10px;
+      padding-right: $s-1;
+      font-size: $font-14;
+      font-weight: $font-medium;
+
+      @include flexCentering;
+    }
+
+    .sb-textfield__input {
+      padding-left: 0;
+      border: 0;
+      box-shadow: none !important;
+
+      &--with-icon-left {
+        padding-left: $s-5;
+      }
+    }
+
+    .sb-textfield__icon--left {
+      left: 0;
+      padding: 0;
+    }
+  }
+
   &__label {
     display: block;
     margin-bottom: 10px;
@@ -39,6 +82,11 @@
     width: 100%;
   }
 
+  &__inner-field {
+    position: relative;
+    width: 100%;
+  }
+
   &__textarea {
     box-sizing: border-box;
     min-height: 130px;
@@ -53,6 +101,7 @@
 
   &__input,
   &__textarea {
+    box-sizing: border-box;
     width: 100%;
     color: $sb-dark-blue;
     font-size: $font-14;


### PR DESCRIPTION
Added a new property called `inline-label` to `SbSelect`, `SbDatepicker`, and `SbTextField` in order to handle a use case defined in this design [figma](https://www.figma.com/file/xErAAHZjBhoKUWWSw1UCqd/%5BSBD-10%5D-Activity-Log?type=design&node-id=363-15146&t=4JltgkB8Q7bJBkNE-0)

![Screenshot 2023-06-22 at 15 53 43](https://github.com/storyblok/storyblok-design-system/assets/7618411/4b7448b3-93aa-4975-8274-54e94112875c)

![Screenshot 2023-06-22 at 15 52 06](https://github.com/storyblok/storyblok-design-system/assets/7618411/0dfcb477-b85b-41ba-b83f-1f119f130fde)

https://github.com/storyblok/storyblok-design-system/assets/7618411/45924883-368a-4dff-800e-d2a6a871e558


<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [WORK-1090](https://storyblok.atlassian.net/browse/WORK-1090)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Please check if the `SbSelect`, `SbDatepicker`, and `SbTextField` still working and if it's good with the new property

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Should be possible to pass a prop `inline-label` to show a text inside the `SbSelect`, `SbDatepicker`, and `SbTextField`

## Other information


[WORK-1090]: https://storyblok.atlassian.net/browse/WORK-1090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ