### PR TITLE
feat(work-1116): adding a rightIcon slot to the SbSelect component

### DIFF
--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -45,6 +45,10 @@
         <slot name="selection" v-bind="scope" />
       </template>
 
+      <template #rightIcon>
+        <slot name="rightIcon" />
+      </template>
+
       <slot name="innerSelect" />
     </SbSelectInner>
 

--- a/src/components/Select/__tests__/Select.spec.js
+++ b/src/components/Select/__tests__/Select.spec.js
@@ -1165,4 +1165,34 @@ describe('SbSelect component', () => {
       ).toBe(false)
     })
   })
+
+  describe('rightIcon slot', () => {
+    const factory = (slots = {}) => {
+      return mountAttachingComponent(SbSelect, {
+        props: {
+          label: 'Choose an option',
+          options: [...defaultSelectOptionsData],
+        },
+        slots,
+      })
+    }
+
+    it('should render the arrow icon by default', () => {
+      const wrapper = factory()
+
+      expect(
+        wrapper.find('.sb-select-inner__chevron').exists()
+      ).toBeTruthy()
+    })
+
+    it('should render the rightIcon slot if present', () => {
+      const wrapper = factory({
+        rightIcon: '<span class="custom-right-icon" />',
+      })
+
+      expect(
+        wrapper.find('.custom-right-icon').exists()
+      ).toBeTruthy()
+    })
+  })
 })

--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -121,8 +121,9 @@ class="sb-select-inner__avatar">
         <SbIcon name="x-clear" />
       </button>
 
-      <SbIcon class="sb-select-inner__chevron"
-:name="rightIconName" />
+      <slot name="rightIcon">
+        <SbIcon class="sb-select-inner__chevron" :name="rightIconName" />
+      </slot>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Added a new slot called `rightIcon` to the SbSelect in order to handle a use case defined in this design [figma](https://www.figma.com/file/1szETf2YEv9379Zw3sXqRW/%5BWORK-295%5D-Multiple-Workflows?type=design&node-id=2001-77758&mode=design&t=i0Zcf0ZyNDQpbLZs-0)

![Screenshot 2023-06-29 at 15 13 30](https://github.com/storyblok/storyblok-design-system/assets/7618411/edabad0a-008e-4420-897c-23ba442a9fd6)


https://github.com/storyblok/storyblok-design-system/assets/7618411/68d69758-77a4-4ded-9be4-51d2bdff0910


## Pull request type

Jira Link: [WORK-1116](https://storyblok.atlassian.net/browse/WORK-1116)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Please check if the `SbSelect` still working as before

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now should be possible to pass a slot to be used as the right icon

## Other information


[WORK-1116]: https://storyblok.atlassian.net/browse/WORK-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ