### PR TITLE
style: fix icon in avatar when size is large

### DIFF
--- a/src/components/Avatar/avatar.scss
+++ b/src/components/Avatar/avatar.scss
@@ -67,6 +67,7 @@
   &--large {
     .sb-avatar__image,
     .sb-avatar__initials,
+    .sb-icon--custom.sb-icon--large,
     img,
     svg {
       width: $sb-avatar-large;


### PR DESCRIPTION
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

This prevents this to happen:

BEFORE:
![Screenshot 2023-07-27 alle 12 46 40](https://github.com/storyblok/storyblok-design-system/assets/4409084/35d0223e-8b2b-4bbb-84f0-2879c8e34244)

NOW:
<img width="592" alt="Screenshot 2023-07-27 alle 13 57 12" src="https://github.com/storyblok/storyblok-design-system/assets/4409084/c8961360-81fc-43c3-9607-b45b52a12cf4">


## Other information
