### PR TITLE
docs(sbLoading): fix style in sbLoading when the user are in docs

### DIFF
--- a/src/components/Loading/Loading.stories.js
+++ b/src/components/Loading/Loading.stories.js
@@ -219,9 +219,7 @@ SpinnerWithPercentage.parameters = {
 
 export const LoadingWithPlaceholder = (args) => ({
   components: { SbLoading, SbLoadingPlaceholder },
-  setup() {
-    return { args }
-  },
+  props: Object.keys(args),
   template: `
     <SbLoading :type="type">
       <SbLoadingPlaceholder :width="width" :height="height" style="margin-bottom: 10px"/>

--- a/src/components/Loading/LoadingBlockUi.stories.js
+++ b/src/components/Loading/LoadingBlockUi.stories.js
@@ -2,13 +2,19 @@ import { SbLoading } from './index'
 import { availableColors } from '../../utils'
 import { loadingTypes, loadingSizes } from './utils'
 
-const LoadingBlockTemplate = (args) => ({
+const LoadingBlockTemplate = (args, storyContext) => ({
   components: { SbLoading },
   setup() {
     return { args }
   },
+  computed: {
+    styleForDocs() {
+      if (storyContext.viewMode === 'docs') return 'position: inherit'
+    },
+  },
   template: `
     <SbLoading
+      :style="styleForDocs"
       v-bind="args"
     />
   `,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Fix storie in sbLoading when the user are in docs.

Before:
![image](https://github.com/storyblok/storyblok-design-system/assets/8209305/98f61707-4b8a-42f0-b6da-1bf17a5f7a65)

Now:
![image](https://github.com/storyblok/storyblok-design-system/assets/8209305/5a11c1ed-35d9-474a-9301-647ddfcf5e08)


## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Go to > Interface > SbLoading
Check if the page is ok.

## Other information
