### PR TITLE
fix(work-1073): show remaining character only when limit is close

### DIFF
--- a/src/components/TextField/SbTextField.vue
+++ b/src/components/TextField/SbTextField.vue
@@ -124,18 +124,8 @@
       {{ errorMessage }}
     </span>
 
-    <span
-      v-if="showCounter"
-      class="sb-textfield__counter"
-      :class="{ 'sb-textfield__counter--warning': isAlmostRaiseMaxlength }"
-    >
-      <template v-if="!isAlmostRaiseMaxlength">
-        {{ remainingValue }} characters remaining
-      </template>
-
-      <template v-else>
-        {{ remainingValue }}/{{ maxlengthParsed }} characters remaining
-      </template>
+    <span v-if="showCounter" class="sb-textfield__counter">
+      {{ remainingValue }}/{{ maxlengthParsed }} characters remaining
     </span>
   </div>
 </template>
@@ -257,7 +247,11 @@ export default {
 
     showCounter() {
       return (
-        this.maxlength && !this.showError && this.hasValue && this.isOnInput
+        this.maxlength &&
+        this.isAlmostRaiseMaxlength &&
+        !this.showError &&
+        this.hasValue &&
+        this.isOnInput
       )
     },
 

--- a/src/components/TextField/__tests__/TextField.spec.js
+++ b/src/components/TextField/__tests__/TextField.spec.js
@@ -70,7 +70,7 @@ describe('SbTextField component', () => {
     const iconElement = wrapper.find('svg')
 
     await iconElement.trigger('click')
-    expect(wrapper.vm.computedValue).toBe(null)
+    expect(wrapper.vm.computedValue).toBeNull()
   })
 
   it('should perform v-model', async () => {
@@ -125,13 +125,14 @@ describe('SbTextField component', () => {
 
     await wrapper.vm.$nextTick()
 
-    const remaining = wrapper.find('.sb-textfield__counter')
+    let remaining = wrapper.find('.sb-textfield__counter')
 
-    expect(remaining.text()).toBe('10 characters remaining')
+    expect(remaining.exists()).toBeFalsy()
 
     await inputElement.setValue('Luke Skywalker')
 
-    expect(remaining.classes('sb-textfield__counter--warning')).toBe(true)
+    remaining = wrapper.find('.sb-textfield__counter')
+
     expect(remaining.text()).toBe('1/15 characters remaining')
 
     await inputElement.setValue('')
@@ -144,17 +145,15 @@ describe('SbTextField component', () => {
       inlineLabel: 'Inline label',
     })
 
-    expect(
-      wrapper.find('.sb-textfield__inner-label').text()
-    ).toBe('Inline label')
+    expect(wrapper.find('.sb-textfield__inner-label').text()).toBe(
+      'Inline label'
+    )
   })
 
   it('should not render the inline label by default', () => {
     const wrapper = factory()
 
-    expect(
-      wrapper.find('.sb-textfield__inner-label').exists()
-    ).toBe(false)
+    expect(wrapper.find('.sb-textfield__inner-label').exists()).toBe(false)
   })
 })
 

--- a/src/components/TextField/textfield.scss
+++ b/src/components/TextField/textfield.scss
@@ -251,14 +251,10 @@
   &__counter {
     display: block;
     margin-top: 5px;
-    color: $sb-dark-blue-50;
+    color: $orange;
     font-size: $font-14;
     font-weight: $font-regular;
     letter-spacing: 0;
-
-    &--warning {
-      color: $orange;
-    }
   }
 
   &__required {


### PR DESCRIPTION
Situation:

> When there are limits for characters in some fields, the label “`n` characters remaining” is used incorrectly.
> There should be displayed only when the character limit is close.

![image](https://github.com/storyblok/storyblok-design-system/assets/7618411/0f53b92e-f58b-495c-8be0-d5e51e55ada6)

![image](https://github.com/storyblok/storyblok-design-system/assets/7618411/d781e393-b9ab-4370-84a7-0daa4d11f6d8)

## Pull request type

Jira Link: [WORK-1073](https://storyblok.atlassian.net/browse/WORK-1073)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The remaining characters' text should only appear when the limit is close

## Other information


[WORK-1073]: https://storyblok.atlassian.net/browse/WORK-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ