### PR TITLE
fix(work-1256): increase SbDataTable actions sticky version z-index

### DIFF
--- a/src/components/DataTable/data-table.scss
+++ b/src/components/DataTable/data-table.scss
@@ -193,7 +193,7 @@
   &--sticky {
     position: sticky;
     top: 10px;
-    z-index: 1;
+    z-index: 2;
   }
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Increases the `z-index` CSS property of the `SbDataTableActions` component so that it sets on top of other components

## Pull request type

Jira Link: [WORK-1256](https://storyblok.atlassian.net/browse/WORK-1256)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `SbDataTableActions` z-index should be `2` to prevent it from being below other absolute elements (see example below)
 
<img width="1285" alt="image" src="https://github.com/storyblok/storyblok-design-system/assets/4389464/b2a025cb-f1ea-4fb5-add8-314dc6336145">


## Other information


[WORK-1177]: https://storyblok.atlassian.net/browse/WORK-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WORK-1256]: https://storyblok.atlassian.net/browse/WORK-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ