### PR TITLE
feat(work-1303): add data-testid to SbModal close button

### DIFF
--- a/src/components/Modal/SbModal.vue
+++ b/src/components/Modal/SbModal.vue
@@ -109,7 +109,6 @@ export default {
     },
 
     computedClasses() {
-      console.log('io', this.$attrs)
       return [
         this.customClass?.length && this.customClass,
         this.fullWidth && 'sb-modal__full-width',

--- a/src/components/Modal/SbModal.vue
+++ b/src/components/Modal/SbModal.vue
@@ -8,7 +8,12 @@
     :target="modalTarget"
     :disabled="disabledTargetDefault"
   >
-    <SbBlokUi v-if="open" :style="computedBlokUiStyle" :full-width="fullWidth" @mousedown="wrapClose">
+    <SbBlokUi
+      v-if="open"
+      :style="computedBlokUiStyle"
+      :full-width="fullWidth"
+      @mousedown="wrapClose"
+    >
       <div
         ref="modal"
         class="sb-modal"
@@ -17,7 +22,10 @@
         :style="computedStyle"
         v-bind="$attrs"
       >
-        <SbModalCloseButton v-if="showClose" />
+        <SbModalCloseButton
+          v-if="showClose"
+          :data-testid="closeButtonDataTestId"
+        />
         <slot />
       </div>
     </SbBlokUi>
@@ -95,7 +103,13 @@ export default {
   },
 
   computed: {
+    closeButtonDataTestId() {
+      const dataTestId = this.$attrs['data-testid']
+      return dataTestId ? `${dataTestId}-close-button` : 'sb-modal-close-button'
+    },
+
     computedClasses() {
+      console.log('io', this.$attrs)
       return [
         this.customClass?.length && this.customClass,
         this.fullWidth && 'sb-modal__full-width',

--- a/src/components/Modal/components/SbModalCloseButton.vue
+++ b/src/components/Modal/components/SbModalCloseButton.vue
@@ -3,7 +3,6 @@
     class="sb-modal__close-button"
     aria-label="Close Modal"
     @click="handleCloseModal"
-    data-testid="close-modal-button"
   >
     <SbIcon name="x" color="primary-dark" />
   </button>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [WORK-1303](https://storyblok.atlassian.net/browse/WORK-1303)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR


There's not much to test, since this is a purely QA-oriented ticket.

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add dynamic `data-testid` to the `SbModal` close button falling back to `sb-modal-close-button`


## Other information


[WORK-1303]: https://storyblok.atlassian.net/browse/WORK-1303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ