### PR TITLE
story(STR-1711): ✨  add a customizable minute range for datepicker

### DIFF
--- a/src/components/Datepicker/Datepicker.stories.js
+++ b/src/components/Datepicker/Datepicker.stories.js
@@ -23,6 +23,7 @@ const Template = (args) => ({
         style="width: 29.4rem"
         :min-date="minDate"
         :max-date="maxDate"
+        :minute-range="minuteRange"
         :disabled-past="disabledPast"
         :inline-label="inlineLabel"
       />
@@ -43,6 +44,7 @@ export default {
     tzTooltip: '',
     minDate: '',
     maxDate: '',
+    minuteRange: 1,
     disabledPast: false,
   },
   argTypes: {
@@ -129,6 +131,15 @@ export default {
         type: 'text',
       },
     },
+    minuteRange: {
+      name: 'minuteRange',
+      description:
+        'The range the minutes should be displayed. WARNING: the range number should be a multiplier of 60, if not it will fallback to 1',
+      defaultValue: 1,
+      control: {
+        type: 'number',
+      },
+    },
     disabledPast: {
       name: 'disabledPast',
       description:
@@ -140,7 +151,8 @@ export default {
     },
     inlineLabel: {
       name: 'inlineLabel',
-      description: 'Use the `inline-label` property to add text inside the field',
+      description:
+        'Use the `inline-label` property to add text inside the field',
       defaultValue: '',
       table: {
         type: { summary: 'String' },
@@ -156,6 +168,10 @@ export default {
 export const Default = Template.bind({})
 
 export const TimeType = Template.bind({})
+
+TimeType.args = {
+  minuteRange: 5,
+}
 
 TimeType.parameters = {
   docs: {
@@ -244,7 +260,7 @@ DisabledDatePast.parameters = {
 export const WithInlineLabel = Template.bind({})
 
 WithInlineLabel.args = {
-  inlineLabel: 'Date:'
+  inlineLabel: 'Date:',
 }
 
 WithInlineLabel.parameters = {

--- a/src/components/Datepicker/Datepicker.vue
+++ b/src/components/Datepicker/Datepicker.vue
@@ -12,6 +12,7 @@
         type="text"
         icon-left="calendar"
         :disabled="disabled"
+        :readonly="isInputReadonly"
         :placeholder="placeholder"
         :model-value="internalValueFormatted"
         :error="invalidDate"
@@ -32,8 +33,7 @@
           {{ tzOffsetLabel }}
         </span>
 
-        <span v-else
-class="sb-datepicker__timezone">
+        <span v-else class="sb-datepicker__timezone">
           {{ tzOffsetLabel }}
         </span>
       </template>
@@ -64,6 +64,7 @@ class="sb-datepicker__timezone">
         :internal-date="internalDate"
         :min-date="minDate"
         :max-date="maxDate"
+        :minute-range="minuteRange"
         :disabled-past="disabledPast"
         @update:model-value="handleComponentsInput"
         @input-minutes="handleMinutesInput"
@@ -187,6 +188,11 @@ export default {
       type: String,
       default: '',
     },
+
+    minuteRange: {
+      type: Number,
+      default: 1,
+    },
   },
 
   emits: ['clear', 'update:modelValue'],
@@ -213,6 +219,9 @@ export default {
   }),
 
   computed: {
+    isInputReadonly() {
+      return this.minuteRange > 1
+    },
     hasDayDisabled() {
       return this.maxDate || this.minDate || this.disabledPast
     },

--- a/src/components/Datepicker/components/DatepickerTime.vue
+++ b/src/components/Datepicker/components/DatepickerTime.vue
@@ -40,6 +40,10 @@ export default {
       type: String,
       default: null,
     },
+    minuteRange: {
+      type: Number,
+      default: 1,
+    },
   },
 
   emits: ['update:modelValue', 'input-minutes'],
@@ -66,8 +70,9 @@ export default {
     minutes() {
       const list = []
       let min = 60
+      const minuteRange = min % this.minuteRange === 0 ? this.minuteRange : 0
       while (min > 0) {
-        min--
+        minuteRange > 1 ? (min = min - minuteRange) : min--
         list.push({
           checked: min === this.internalMinutes,
           value: min < 10 ? '0' + min : min,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [STR-1711](https://storyblok.atlassian.net/browse/STR-1711)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Go to the [design system](https://storyblok-design-system-git-story-str-1711-f0d333-storyblok-com.vercel.app/?path=/story/forms-sbdatepicker--time-type) to test

## What is the new behavior?

Now with the new prop minuteRange you can define a number divisible by 60 to set at what internal the minutes should shown

<img width="363" alt="Screenshot 2023-09-08 alle 10 58 48" src="https://github.com/storyblok/storyblok-design-system/assets/4409084/4a9248b8-829f-40ea-9531-f4cf78be2330">


## Other information


[STR-1711]: https://storyblok.atlassian.net/browse/STR-1711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ