### PR TITLE
♻️  refactor(#452): rename SbPagination events names

### DIFF
--- a/src/components/Pagination/SbPagination.vue
+++ b/src/components/Pagination/SbPagination.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-class="sb-pagination" :class="computedClasses"
->
+  <div class="sb-pagination" :class="computedClasses">
     <template v-if="carousel || compact || hasNextPrevBtn">
       <SbPaginationButton
         v-if="hasNextPrevBtn"
@@ -199,13 +197,13 @@ export default {
     handlePreviousPage() {
       if (!this.isFirstDisabled) {
         this.updateValue(this.modelValue - 1)
-        this.$emit('on-previous-page', this.modelValue - 1)
+        this.$emit('previous-page', this.modelValue - 1)
       }
     },
     handleNextPage() {
       if (!this.isLastDisabled) {
         this.updateValue(this.modelValue + 1)
-        this.$emit('on-next-page', this.modelValue + 1)
+        this.$emit('next-page', this.modelValue + 1)
       }
     },
     onPageChange(page) {


### PR DESCRIPTION
Related to this Github issue: https://github.com/storyblok/storyblok-design-system/issues/452

## Pull request type

Jira Link: [STR-1963](https://storyblok.atlassian.net/browse/STR-1963)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

In the storybook doc of the SbPagination, the code for the component should have the proper names for the events:
```
v-on:previous-page
v-on:next-page
```

## What is the new behavior?

Events name are changed: `on-previous-page` becomes `previous-page` and `on-next-page` becomes `next-page`

## Other information


[STR-1963]: https://storyblok.atlassian.net/browse/STR-1963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ