### PR TITLE
feat(work-1342): introduce data-testids Minbrowser, Select, Avatar, B…

### DIFF
--- a/src/components/Avatar/SbAvatar.vue
+++ b/src/components/Avatar/SbAvatar.vue
@@ -2,7 +2,7 @@
   <div v-tooltip="avatarTooltipAttrs" :class="avatarClass" v-bind="$attrs">
     <template v-if="showImage">
       <slot>
-        <div class="sb-avatar__image" :style="avatarStyle">
+        <div class="sb-avatar__image" :style="avatarStyle" :data-testid="`${dataTestid}-image`">
           <img
             v-show="isImageLoaded"
             :src="src"
@@ -17,23 +17,23 @@
             :color="fallbackAvatarColor"
           />
         </div>
-        <SbBadge v-if="!!status" v-bind="badgeAttrs" />
+        <SbBadge v-if="!!status" v-bind="badgeAttrs" :data-testid="`${dataTestid}-badge`"/>
       </slot>
     </template>
     <template v-else-if="name || friendlyName">
-      <div :class="avatarInitialsClass">
+      <div :class="avatarInitialsClass" :data-testid="`${dataTestid}-initials`">
         <span>{{ initials }}</span>
         <SbBadge v-if="!!status" v-bind="badgeAttrs" />
       </div>
     </template>
     <div v-if="showTextContainer" class="sb-avatar__text-container">
-      <span v-if="isDescriptionTop" :class="descriptionClass">
+      <span v-if="isDescriptionTop" :class="descriptionClass" :data-testid="`${dataTestid}-top-description`">
         {{ description }}
       </span>
-      <span class="sb-avatar__text">
+      <span class="sb-avatar__text" :data-testid="`${dataTestid}-text`">
         {{ friendlyName || name }}
       </span>
-      <span v-if="isDescriptionBottom" :class="descriptionClass">
+      <span v-if="isDescriptionBottom" :class="descriptionClass" :data-testid="`${dataTestid}-bottom-description`">
         {{ description }}
       </span>
     </div>
@@ -132,6 +132,10 @@ export default {
   },
 
   computed: {
+    dataTestid() {
+      return this.$attrs['data-testid'] || 'sb-avatar'
+    },
+
     avatarClass() {
       const avatarSizeClass =
         this.size && this.size !== 'normal' && `sb-avatar--${this.size}`

--- a/src/components/Badge/SbBadge.vue
+++ b/src/components/Badge/SbBadge.vue
@@ -1,9 +1,9 @@
 <template>
   <div :class="activeClasses">
-    <SbIcon v-if="isRenderIcon" :name="iconName" />
-    <span v-if="hasLabelToRender" class="sb-badge__label"
-      ><slot>{{ activeLabel }}</slot></span
-    >
+    <SbIcon v-if="isRenderIcon" :name="iconName" :data-testid="`${dataTestId}-icon`"/>
+    <span v-if="hasLabelToRender" class="sb-badge__label" :data-testid="`${dataTestid}-active-label`">
+      <slot>{{ activeLabel }}</slot>
+    </span>
     <slot v-else></slot>
   </div>
 </template>
@@ -50,7 +50,7 @@ export default {
     },
   },
 
-  setup(props, { slots }) {
+  setup(props, { slots, attrs }) {
     const isRenderIcon = !props.contract && !isValidNumber(props.number)
     const activeLabel = isValidNumber(props.number) ? props.number : props.label
     const isLabelAllowed = !props.contract && !props.onlyIcon
@@ -67,6 +67,7 @@ export default {
       },
     ])
     const iconName = computed(() => mapIconByTypes[props.type])
+    const dataTestid = computed(() => attrs['data-testid'] || 'sb-badge')
 
     return {
       isRenderIcon,
@@ -74,6 +75,7 @@ export default {
       activeClasses,
       activeLabel,
       iconName,
+      dataTestid
     }
   },
 }

--- a/src/components/Minibrowser/Minibrowser.vue
+++ b/src/components/Minibrowser/Minibrowser.vue
@@ -9,10 +9,11 @@
   >
     <SbMinibrowserSearch
       v-if="!hideSearch"
+      :data-testid="`${dataTestid}-search`"
       :clear-search-label="clearSearchLabel"
       :model-value="searchInput"
       :placeholder="placeholder"
-      @update:modelValue="handleSearchInput"
+      @update:model-value="handleSearchInput"
       @keydown="handleSearchKeydown"
     />
 
@@ -21,6 +22,7 @@
       <SbMinibrowserBreadcrumbs
         v-if="hasBreadcrumbs"
         :items="internalBreadcrumbs"
+        :data-testid="`${dataTestid}-breadcrumbs`"
       />
 
       <template v-if="hasGroupedItems">
@@ -29,6 +31,7 @@
             v-if="!$slots.list"
             :key="index"
             v-bind="groupItem"
+            :data-testid="`${dataTestid}-list`"
           />
 
           <slot name="list" v-bind="groupItem" />
@@ -36,13 +39,21 @@
       </template>
 
       <template v-if="hasOtherItems">
-        <SbMinibrowserList v-if="!$slots.list" :items="otherItems" />
+        <SbMinibrowserList
+          v-if="!$slots.list"
+          :items="otherItems"
+          :data-testid="`${dataTestid}-additional-list`"
+        />
 
         <slot name="list" :items="otherItems" />
       </template>
     </div>
 
-    <p v-if="hasNotFilteredElements" class="sb-minibrowser__not-found">
+    <p
+      v-if="hasNotFilteredElements"
+      class="sb-minibrowser__not-found"
+      :data-testid="`${dataTestid}-not-found-text`"
+    >
       {{ notFoundText }}
     </p>
   </div>
@@ -134,6 +145,10 @@ export default {
   }),
 
   computed: {
+    dataTestid() {
+      return this.$attrs['data-testid'] || 'sb-mini-browser'
+    },
+
     browserContext() {
       return {
         // browser states

--- a/src/components/Minibrowser/components/MinibrowserBreadcrumbs.vue
+++ b/src/components/Minibrowser/components/MinibrowserBreadcrumbs.vue
@@ -16,6 +16,7 @@
           :is-active="index === lastIndex"
           v-bind="item"
           @click="navigateTo($event, index)"
+          :data-testid="`${dataTestid}-item-${index}`"
         />
 
         <SbBreadcrumbSeparator
@@ -52,6 +53,10 @@ export default {
   },
 
   computed: {
+    dataTestid() {
+      return this.$attrs['data-testid'] || 'sb-mini-browser-breadcrumbs'
+    },
+
     context() {
       return this.browserContext()
     },

--- a/src/components/Minibrowser/components/MinibrowserList.vue
+++ b/src/components/Minibrowser/components/MinibrowserList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="sb-minibrowser__list">
-    <SbMiniBrowserListHeader v-if="isInternalTitleVisible" :title="title" />
+    <SbMiniBrowserListHeader v-if="isInternalTitleVisible" :title="title" :data-testid="`${dataTestid}-header`" />
 
     <slot name="header" :title="title" />
 
@@ -14,6 +14,7 @@
           ...item,
           modelValue: item.value,
         }"
+        :data-testid="`${dataTestid}-item-${key}`"
       />
     </ul>
   </div>
@@ -44,6 +45,10 @@ export default {
   },
 
   computed: {
+    dataTestid() {
+      return this.$attrs['data-testid'] || 'sb-mini-browser-list'
+    },
+
     isInternalTitleVisible() {
       return this.title && !this.$slots.header
     },

--- a/src/components/Minibrowser/components/MinibrowserSearch.vue
+++ b/src/components/Minibrowser/components/MinibrowserSearch.vue
@@ -9,6 +9,7 @@
       ref="input"
       class="sb-textfield__input sb-textfield__input--default sb-textfield__input--ghost-light"
       type="search"
+      :data-testid="`${dataTestid}-input`"
       :value="modelValue"
       :placeholder="placeholder"
       @input="handleSearchInput"
@@ -60,6 +61,10 @@ export default {
   emits: ['update:modelValue', 'keydown'],
 
   computed: {
+    dataTestid() {
+      return this.$attrs['data-testid'] || 'sb-mini-browser-search'
+    },
+
     context() {
       return this.browserContext()
     },

--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -34,6 +34,7 @@
       :item-caption="itemCaption"
       :inline-label="inlineLabel"
       :show-count="showCount"
+      :data-testid="`${dataTestid}-inner`"
       @click="handleSelectInnerClick"
       @keydown-enter="handleKeyDownEnter"
       @search="handleSearchInput"
@@ -81,6 +82,7 @@
       :all-option-value="firstOptionValue"
       :first-value-is-all-value="firstValueIsAllValue"
       :is-option-disabled="isOptionDisabled"
+      :data-testid="`${dataTestid}-list`"
       @emit-value="handleEmitValue"
       @option-created="handleOptionCreated"
       @focus-item="focusAtIndex($event)"
@@ -252,6 +254,10 @@ export default {
   }),
 
   computed: {
+    dataTestid() {
+      return this.$attrs['data-testid'] || 'sb-select'
+    },
+
     selectContext() {
       return {
         // controls elements

--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -22,7 +22,7 @@
 
     <div v-if="isTagsVisible" class="sb-select-inner__tags">
       <div v-if="showCount">
-        <SelectInnerTag 
+        <SelectInnerTag
             :item="firstTagLabel"
             :item-label="itemLabel"
             :item-value="itemValue"
@@ -33,6 +33,7 @@
             :value-tag-count="tagLabels.length - 1"
             :is-disabled="isDisabled"
             :tags-count-tooltip="tagsCountTooltip"
+            :data-testid="`${dataTestid}-tag-show-count`"
             @keydown="handleTagKeydown($event, firstTagLabel)"
             @close="removeItem($event, firstTagLabel)"
           />
@@ -44,7 +45,7 @@
           :item="tagLabel"
           :remove="(e) => removeItem(e, tagLabel)"
         >
-          <SelectInnerTag 
+          <SelectInnerTag
               :item="tagLabel"
               :item-label="itemLabel"
               :item-value="itemValue"
@@ -52,6 +53,7 @@
               :show-caption="showCaption"
               :is-tag-avatar-visible="isTagAvatarVisible"
               :is-disabled="isDisabled"
+              :data-testid="`${dataTestid}-tag`"
               @keydown="handleTagKeydown($event, tagLabel)"
               @close="removeItem($event, tagLabel)"
             />
@@ -69,6 +71,7 @@
         :style="inlineWidth"
         :placeholder="placeholderLabel"
         :readonly="!filterable"
+        :data-testid="`${dataTestid}-search-input`"
         @focus="handleEmitSearchInput"
       />
     </div>
@@ -79,6 +82,7 @@
         size="small"
         show-name
         :name="innerLabel"
+        :data-testid="`${dataTestid}-avatar`"
       />
     </div>
 
@@ -92,6 +96,7 @@
       :style="inlineWidth"
       :placeholder="placeholderLabel"
       :readonly="!filterable || inline"
+      :data-testid="`${dataTestid}-search-input`"
       @focus="handleEmitSearchInput"
     />
 
@@ -114,6 +119,7 @@
         v-tooltip="{ label: 'Clear selection' }"
         aria-label="Clear all values"
         class="sb-select-inner__clear"
+        :data-testid="`${dataTestid}-clear-button`"
         type="button"
         @keydown="clearAllValuesKeydown"
         @click="clearAllValues"
@@ -122,7 +128,7 @@
       </button>
 
       <slot name="rightIcon">
-        <SbIcon class="sb-select-inner__chevron" :name="rightIconName" />
+        <SbIcon class="sb-select-inner__chevron" :name="rightIconName" :data-testid="`${dataTestid}-right-icon`"/>
       </slot>
     </div>
   </div>
@@ -238,6 +244,10 @@ export default {
   }),
 
   computed: {
+    dataTestid() {
+      return this.$attrs['data-testid'] || 'sb-select-inner'
+    },
+
     searchInputText: {
       get() {
         return this.searchInput

--- a/src/components/Select/components/SelectInnerTag.vue
+++ b/src/components/Select/components/SelectInnerTag.vue
@@ -5,6 +5,7 @@
     :closable="!isDisabled"
     @keydown="$emit('keydown', $event, item)"
     @close="$emit('close', $event, item)"
+    :data-testid="`${dataTestid}-tag`"
   >
     <template v-if="item">
       <SbAvatar
@@ -13,8 +14,9 @@
         :src="getSource(item)"
         size="small"
         :name="item[itemLabel]"
+        :data-testid="`${dataTestid}-avatar`"
       />
-      <span class="sb-select-inner__tag" :title="getTagTitle(item)">
+      <span class="sb-select-inner__tag" :title="getTagTitle(item)" :data-testid="`${dataTestid}-inner-tag`">
         <template v-if="showCaption">
           {{ item[itemLabel] }}
           <span v-if="item[itemCaption]">({{ item[itemCaption] }})</span>
@@ -85,6 +87,12 @@ export default {
   },
 
   emits: ['keydown', 'close'],
+
+  computed: {
+    dataTestid() {
+      return this.$attrs['data-testid'] || 'sb-select-inner-tag'
+    }
+  },
 
   methods: {
     getSource(label) {

--- a/src/components/Select/components/SelectList.vue
+++ b/src/components/Select/components/SelectList.vue
@@ -22,12 +22,12 @@
           :path="option[itemCaption]"
           :selected="shouldBeChecked(index)"
           :is-disabled="isOptionDisabled(option)"
+          :data-testid="`${dataTestid}-item__${index}`"
           @emit-value="handleEmitValue"
           @mouseenter="handleFocusItem(index)"
         >
           <template #list-item="scope">
-            <slot name="list-item"
-v-bind="scope" />
+            <slot name="list-item" v-bind="scope" />
           </template>
         </SbSelectListItem>
       </template>
@@ -38,22 +38,20 @@ v-bind="scope" />
         @click="handleOptionCreated(searchInput)"
       >
         <span class="sb-select-list__create-label">Create tag</span>
-        <span class="sb-select-list__create-value"
-:title="searchInput">
+        <span class="sb-select-list__create-value" :title="searchInput" :data-testid="`${dataTestid}-create-search`">
           "{{ searchInput }}"
         </span>
       </li>
       <li v-else-if="isLoadingMore">
-        <span class="sb-select-list__empty">
-          <SbLoading color="primary"
-size="small" />
+        <span class="sb-select-list__empty" :data-testid="`${dataTestid}-loading-more`">
+          <SbLoading color="primary" size="small" />
           {{ loadingMoreText }}
         </span>
       </li>
-      <li v-else-if="showTextStartingTagCreation">
+      <li v-else-if="showTextStartingTagCreation" :data-testid="`${dataTestid}-no-data-text-tag`">
         <span class="sb-select-list__empty"> {{ noDataTextTag }} </span>
       </li>
-      <li v-else-if="!hasOptions && !isLoading">
+      <li v-else-if="!hasOptions && !isLoading" :data-testid="`${dataTestid}-no-data-text`">
         <span class="sb-select-list__empty">{{ noDataText }}</span>
       </li>
     </ul>
@@ -146,6 +144,10 @@ export default {
   },
 
   computed: {
+    dataTestid() {
+      return this.$attrs['data-testid'] || 'sb-select-list'
+    },
+
     context() {
       return this.selectContext()
     },

--- a/src/components/Select/components/SelectListItem.vue
+++ b/src/components/Select/components/SelectListItem.vue
@@ -12,6 +12,7 @@
       :key="label"
       :src="option.src"
       :name="label"
+      :data-testid="`${dataTestid}-avatar`"
       show-name
       size="small"
     />
@@ -22,22 +23,22 @@
         :model-value="isSelected"
         :disabled="isDisabled"
         non-reactive
+        :data-testid="`${dataTestid}-checkbox`"
       />
 
       <slot name="list-item" :item="option">
-        <span class="sb-select-list__item-icon">
+        <span class="sb-select-list__item-icon" :data-testid="`${dataTestid}-icon`">
           <SbIcon v-if="option.icon" :name="option.icon" />
         </span>
 
-        <span v-if="!showCaption" class="sb-select-list__item-name">{{
-          label
-        }}</span>
+        <span v-if="!showCaption" class="sb-select-list__item-name" :data-testid="`${dataTestid}-label`">
+          {{ label }}
+        </span>
 
         <div v-else class="sb-select-list__item--with-path">
-          <span class="sb-select-list__item-name">{{ label }}</span>
-          <span v-if="showCaption" class="sb-select-list__item-caption">{{
-            path
-          }}</span>
+          <span class="sb-select-list__item-name" :data-testid="`${dataTestid}-label`">{{ label }}</span>
+          <span v-if="showCaption" class="sb-select-list__item-caption" :data-testid="`${dataTestid}-path`">
+            {{ path }}</span>
         </div>
       </slot>
     </template>
@@ -105,6 +106,10 @@ export default {
   emits: ['emit-value'],
 
   computed: {
+    dataTestid() {
+      return this.$attrs['data-testid'] || 'sb-select-list-item'
+    },
+
     isSelected() {
       return isArray(this.inputValue)
         ? this.isValueAlreadyExists()

--- a/src/components/Tag/SbTag.vue
+++ b/src/components/Tag/SbTag.vue
@@ -5,14 +5,16 @@
       class="sb-tag__avatar"
       :src="user.avatar"
       :friendly-name="user.friendly_name"
+      :data-testid="`${dataTestid}-avatar`"
     />
-    <span class="sb-tag__label">
+    <span class="sb-tag__label" :data-testid="`${dataTestid}-label`">
       <slot>
         {{ label }}
       </slot>
     </span>
     <SbIcon
       v-if="closable"
+      :data-testid="`${dataTestid}-remove-button`"
       v-tooltip="{
         label: 'Remove',
         position: 'bottom',
@@ -61,7 +63,12 @@ export default {
   },
 
   emits: ['close'],
+
   computed: {
+    dataTestid() {
+      return this.$attrs['data-testid'] || 'sb-tag'
+    },
+
     computedClass() {
       return [
         `sb-tag sb-tag--${this.type}`,


### PR DESCRIPTION
…adge and Tag components

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [WORK-1342](https://storyblok.atlassian.net/browse/WORK-1342)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Not much testing is needed from anyone else other than QA that will make sure the `data-testids` added are properly introduced to support E2E tests to come.

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Introduces dynamic `data-testids` to a group of components used on the Storyfront _Create folder_ flow


## Other information


[WORK-1342]: https://storyblok.atlassian.net/browse/WORK-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ