### PR TITLE
fix(int-1077): datepicker schedule time last block

### DIFF
--- a/src/components/Datepicker/datepicker.scss
+++ b/src/components/Datepicker/datepicker.scss
@@ -216,7 +216,11 @@
     @include datepickerItem();
 
     &:last-of-type {
-      border-bottom: 0;
+      border-bottom: none;
+    }
+
+    &:nth-child(4) {
+      border-bottom: 1px solid $light;
     }
   }
 }


### PR DESCRIPTION
- Added check for every 4th block to set border bottom

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-1077](https://storyblok.atlassian.net/browse/INT-1077)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Schedule a Publish
- Select day
- Select time, then the border bottom for the minute 00 should be there

## Other information


[INT-1077]: https://storyblok.atlassian.net/browse/INT-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ