### PR TITLE
:bug: fix(ON-1500): adds Esc key listener when is-open is true on created hook

### DIFF
--- a/src/components/Modal/SbModal.vue
+++ b/src/components/Modal/SbModal.vue
@@ -151,6 +151,9 @@ export default {
 
   created() {
     this.$_createPortalInstance()
+    if (this.isOpen) {
+      this.handleCloseModalByPressingEsc()
+    }
   },
 
   beforeUnmount() {


### PR DESCRIPTION
Please have a look at the code change to get the explanation 🙂 

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [ON-1500](https://storyblok.atlassian.net/browse/ON-1500)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
<img width="500" alt="Screenshot 2023-11-08 at 15 27 26" src="https://github.com/storyblok/storyblok-design-system/assets/16685155/46da56b2-1e7a-45c6-a05f-cd302f79ecc6">

- Open the _"What's New"_ modal by clicking on the _"What's New"_ shortcut in the sidebar
- Once the modal is open, hit the ESC key on your keyboard
- The modal should close

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The modal now closes when the user hits the ESC key on his keyboard

## Other information


[ON-1500]: https://storyblok.atlassian.net/browse/ON-1500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ