### PR TITLE
feat(STR-2000): fix rounded corner on the upload progress bar

### DIFF
--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -26,3 +26,7 @@ body {
 .sb-story {
   width: 100%;
 }
+
+#story--interface-sbuploaddialog--default--primary .sb-block-ui {
+  position: static;
+}

--- a/src/components/UploadDialog/UploadDialog.stories.js
+++ b/src/components/UploadDialog/UploadDialog.stories.js
@@ -57,7 +57,7 @@ export default {
       description:
         'The `percentageValue` property defines the percentage of file that being uploaded',
       control: {
-        type: 'text',
+        type: 'number',
       },
     },
     totalFiles: {
@@ -65,7 +65,7 @@ export default {
       description:
         'The `totalFiles` property defines the total of files to upload',
       control: {
-        type: 'text',
+        type: 'number',
       },
     },
     timeLeft: {
@@ -73,7 +73,7 @@ export default {
       description:
         'The `timeLeft` property defines the time to left (in seconds) of actual file that being uploaded',
       control: {
-        type: 'text',
+        type: 'number',
       },
     },
   },

--- a/src/components/UploadDialog/UploadDialog.vue
+++ b/src/components/UploadDialog/UploadDialog.vue
@@ -2,101 +2,77 @@
   <SbBlockUi>
     <div class="sb-upload-dialog">
       <div class="sb-upload-dialog__content">
-        <SbIcon
-name="refreshing" size="small"
-color="primary"
-/>
+        <SbIcon name="refreshing" size="small" color="primary" />
         <span class="sb-upload-dialog__label"> {{ labelToUpload }} </span>
-        <span
-v-if="timeLeft" class="sb-upload-dialog__time-left"
->
+        <span v-if="timeLeft" class="sb-upload-dialog__time-left">
           {{ timeLeftLabel }}
         </span>
       </div>
-      <SbLoading
-type="bar" :model-value="percentageValue"
-/>
+      <SbLoading type="bar" :model-value="percentageValue" />
     </div>
   </SbBlockUi>
 </template>
 
-<script>
+<script setup lang="ts">
+import { computed } from 'vue'
 import SbIcon from '../Icon'
 import SbLoading from '../Loading'
 import SbBlockUi from '../BlockUI'
 import i18n from '../../i18n/index'
 
-export default {
+defineOptions({
   name: 'SbUploadDialog',
+})
 
-  components: {
-    SbIcon,
-    SbLoading,
-    SbBlockUi,
-  },
+const props = withDefaults(
+  defineProps<{
+    currentFile?: number
+    currentFileName?: string
+    percentageValue?: number
+    timeLeft?: number
+    totalFiles?: number
+    locale?: string
+  }>(),
+  {
+    currentFile: 0,
+    percentageValue: 0,
+    timeLeft: 0,
+    totalFiles: 0,
+    locale: 'en',
+  }
+)
 
-  props: {
-    currentFile: {
-      type: Number,
-      default: 0,
-    },
-    currentFileName: {
-      type: String,
-      default: null,
-    },
-    percentageValue: {
-      type: Number,
-      default: 0,
-    },
-    timeLeft: {
-      type: Number,
-      default: 0,
-    },
-    totalFiles: {
-      type: Number,
-      default: 0,
-    },
-    locale: {
-      type: String,
-      required: false,
-      default: 'en',
-    },
-  },
+const labelToUpload = computed(() => {
+  if (props.currentFileName) {
+    return `${uploadingLabel.value} - ${props.currentFileName}`
+  }
+  return uploadingLabel
+})
 
-  computed: {
-    labelToUpload() {
-      if (this.currentFileName) {
-        return `${this.uploadingLabel} - ${this.currentFileName}`
-      }
-      return this.uploadingLabel
-    },
+const uploadingLabel = computed(() => {
+  const ofTranslated = i18n(props.locale, 'of')
+  const fileTranslated = i18n(props.locale, 'file')
+  const filesTranslated = i18n(props.locale, 'files')
+  const uploadingTranslated = i18n(props.locale, 'uploading')
 
-    uploadingLabel() {
-      const ofTranslated = i18n(this.locale, 'of')
-      const fileTranslated = i18n(this.locale, 'file')
-      const filesTranslated = i18n(this.locale, 'files')
-      const uploadingTranslated = i18n(this.locale, 'uploading')
+  if (props.totalFiles === 1) {
+    return `${uploadingTranslated} ${props.currentFile} ${ofTranslated} ${props.totalFiles} ${fileTranslated}`
+  }
+  return `${uploadingTranslated} ${props.currentFile} ${ofTranslated} ${props.totalFiles} ${filesTranslated}`
+})
 
-      if (this.totalFiles === 1) {
-        return `${uploadingTranslated} ${this.currentFile} ${ofTranslated} ${this.totalFiles} ${fileTranslated}`
-      }
-      return `${uploadingTranslated} ${this.currentFile} ${ofTranslated} ${this.totalFiles} ${filesTranslated}`
-    },
+const timeLeftLabel = computed(() => {
+  const time = props.timeLeft
+  const minAndTranslated = i18n(props.locale, 'minAnd')
+  const secLeftTranslated = i18n(props.locale, 'secLeft')
 
-    timeLeftLabel() {
-      const time = parseInt(this.timeLeft)
-      const minAndTranslated = i18n(this.locale, 'minAnd')
-      const secLeftTranslated = i18n(this.locale, 'secLeft')
+  if (time > 59) {
+    const minutes = Math.floor(time / 60)
+    const seconds = time % 60
 
-      if (time > 59) {
-        const minutes = Math.floor(time / 60)
-        const seconds = time % 60
+    return `${minutes} ${minAndTranslated} ${seconds} ${secLeftTranslated}`
+  }
 
-        return `${minutes} ${minAndTranslated} ${seconds} ${secLeftTranslated}`
-      }
-
-      return `${this.timeLeft} ${secLeftTranslated}`
-    },
-  },
-}
+  return `${props.timeLeft} ${secLeftTranslated}`
+})
 </script>

--- a/src/components/UploadDialog/upload-dialog.scss
+++ b/src/components/UploadDialog/upload-dialog.scss
@@ -34,15 +34,15 @@
   }
 
   .sb-loading__bar::-webkit-progress-bar {
-    border-radius: 0 0 $base-border-radius $base-border-radius;
+    border-radius: 0 0 0 $base-border-radius;
   }
 
   .sb-loading__bar::-webkit-progress-value {
-    border-radius: 0 0 $base-border-radius $base-border-radius;
+    border-radius: 0 0 0 $base-border-radius;
   }
 
   .sb-loading__bar::-moz-progress-bar {
-    border-radius: 0 0 $base-border-radius $base-border-radius;
+    border-radius: 0 0 0 $base-border-radius;
   }
 
   &__time-left {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [STR-2000](https://storyblok.atlassian.net/browse/STR-2000)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

https://storyblok-design-system-git-task-str-2000-9b341b-storyblok-com.vercel.app/?path=/docs/interface-sbuploaddialog--documentation

## What is the new behavior?


The progress bar should not be rounded:

BEFORE:
<img width="673" alt="Screenshot 2023-11-21 alle 12 00 56" src="https://github.com/storyblok/storyblok-design-system/assets/4409084/654c908c-934a-4844-ab2f-b5b499c54119">


NOW:
<img width="663" alt="Screenshot 2023-11-21 alle 12 00 02" src="https://github.com/storyblok/storyblok-design-system/assets/4409084/b656a161-9554-48fa-9eee-5ee5c8c70ebf">


## Other information


[STR-2000]: https://storyblok.atlassian.net/browse/STR-2000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ