### PR TITLE
refactor(work-1263): adding data-testid to the MenuGroup component

### DIFF
--- a/src/components/Menu/MenuGroup.vue
+++ b/src/components/Menu/MenuGroup.vue
@@ -1,6 +1,10 @@
 <template>
-  <div role="group">
-    <p v-if="title.length" :class="computedClasses">
+  <div role="group" :data-testid="dataTestid">
+    <p
+      v-if="title.length"
+      :class="computedClasses"
+      :data-testid="`${dataTestid}-title`"
+    >
       {{ title }}
     </p>
     <slot />
@@ -17,6 +21,10 @@ export default {
       default: '',
     },
     isTitleBold: Boolean,
+    dataTestid: {
+      type: String,
+      default: 'menu-group',
+    },
   },
 
   computed: {


### PR DESCRIPTION
On this PR we add `data-testid` to the `src/components/Menu/MenuGroup.vue` component to cover what was requested on this [PR](https://storyblok.atlassian.net/browse/WORK-1263)

## Pull request type

Jira Link: [WORK-1263](https://storyblok.atlassian.net/browse/WORK-1263)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

https://github.com/storyblok/storyblok-design-system/assets/7618411/bf4a4af7-9105-438c-8473-9171bd18a2d9


## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- No new behavior, the markup only need to have the new `data-testid`s

## Other information


[WORK-1263]: https://storyblok.atlassian.net/browse/WORK-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ