### PR TITLE
fix: add empty <th> in single select SbDataTable

### DIFF
--- a/src/components/DataTable/__tests__/DataTable.spec.js
+++ b/src/components/DataTable/__tests__/DataTable.spec.js
@@ -77,6 +77,12 @@ describe('SbDataTable component', () => {
       ).toBe(5)
     })
 
+    it('should render an empty header in the checkbox column', () => {
+      expect(
+        wrapperSbDataTableHeader.findAll('th').length
+      ).toBe(7)
+    })
+
     it('should toggle the color of the checkbox and toggle the background color of the row itself', async () => {
       const row = wrapperSbDataTableBody.findAll('.sb-data-table__row')[2]
 

--- a/src/components/DataTable/components/SbDataTableHeader.vue
+++ b/src/components/DataTable/components/SbDataTableHeader.vue
@@ -2,11 +2,12 @@
   <thead :data-testid="dataTestid">
     <tr :data-testid="`${dataTestid}-list-column`">
       <th
-        v-if="allowSelection && isMultiple"
+        v-if="allowSelection"
         class="sb-data-table__head-cell"
         :data-testid="`${dataTestid}-checkbox-cell`"
       >
         <SbCheckbox
+          v-if="isMultiple"
           v-model="isActive"
           :indeterminate="isIndeterminate"
           :data-testid="`${dataTestid}-checkbox`"


### PR DESCRIPTION
fixes: #485

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

 - added unit test to prevent the bug resurfacing
 - all unit tests pass

## What is the new behavior?

- table heads now align with the content on single-select mode in tables

## Other information
ref: https://github.com/storyblok/storyblok-design-system/issues/485