### PR TITLE
task(shape-14): sbTextField - adding the capability to pass the icon right description

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
         cache: 'yarn'
     - run: yarn
     - run: yarn test:unit

--- a/src/components/TextField/SbTextField.vue
+++ b/src/components/TextField/SbTextField.vue
@@ -90,6 +90,7 @@
         </SbTooltip>
         <SbIcon
           v-if="hasIconRight"
+          v-tooltip="iconRightDescription"
           :name="iconRight"
           class="sb-textfield__icon sb-textfield__icon--right"
           :color="iconColor"
@@ -176,6 +177,10 @@ export default {
       default: '',
     },
     inlineLabel: {
+      type: String,
+      default: '',
+    },
+    iconRightDescription: {
       type: String,
       default: '',
     },


### PR DESCRIPTION
We need to show a tooltip for the right icon of the SbTextfield

![Screenshot 2023-12-29 at 12 05 27](https://github.com/storyblok/storyblok-design-system/assets/7618411/64c8ff07-dc39-4147-b043-2b93e22d92e2)

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [SHAPE-14](https://storyblok.atlassian.net/browse/SHAPE-14)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

Should be possible to show a tooltip for the icon right
## Other information


[SHAPE-14]: https://storyblok.atlassian.net/browse/SHAPE-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ