### PR TITLE
feat(shape-55): add default slot to the SbHeaderTitle component

### DIFF
--- a/src/components/EditorHeader/__tests__/HeaderTitle.spec.js
+++ b/src/components/EditorHeader/__tests__/HeaderTitle.spec.js
@@ -22,4 +22,21 @@ describe('Test if Header title renderer correctly', () => {
 
     expect(wrapper.findComponent(SbButton).exists()).toBe(true)
   })
+
+  it('Test to check if the default slot renders correctly', () => {
+    const defaultSlotText = 'Just a text'
+    const wrapper = mount(SbHeaderTitle, {
+      props: {
+        headerTitle: 'Awesome cms',
+        headerSubtitle: 'Its true',
+      },
+      slots: {
+        default: `<span data-testid="default-slot-text"> ${defaultSlotText} </span>`,
+      },
+    })
+
+    expect(wrapper.find('[data-testid="default-slot-text"]').text()).toBe(
+      defaultSlotText,
+    )
+  })
 })

--- a/src/components/EditorHeader/components/HeaderTitle.vue
+++ b/src/components/EditorHeader/components/HeaderTitle.vue
@@ -10,6 +10,7 @@
       <p>{{ headerTitle }}</p>
       <p class="sb-editor-header__subtitle">{{ headerSubtitle }}</p>
     </div>
+    <slot />
   </div>
 </template>
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [SHAPE-55](https://storyblok.atlassian.net/browse/SHAPE-55)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

Nothing should be changed in the SbHeaderTitle component. The PR adds support for a default slot in this component.

## Other information


[SHAPE-55]: https://storyblok.atlassian.net/browse/SHAPE-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ