### PR TITLE
style(on-1601): add min-height to sidebar icons

### DIFF
--- a/src/components/Sidebar/sidebar.scss
+++ b/src/components/Sidebar/sidebar.scss
@@ -126,6 +126,7 @@
   list-style: none;
 
   svg {
+    min-height: $s-5;
     min-width: $s-5;
   }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [ON-1601](https://storyblok.atlassian.net/browse/ON-1601)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other (please describe): add style

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

As some icons don't have 24px of height, when using them in the sidebar the sidebar items end up having a smaller height. For example:

<img width="327" alt="Captura de Tela 2024-01-05 às 12 01 24" src="https://github.com/storyblok/storyblok-design-system/assets/26799272/b91b6365-6f90-4c8a-88b1-9ac8e682fb0c">

By setting a `min-height` of 24px, like we do for the `min-width`, all icons will be the same:

<img width="329" alt="Captura de Tela 2024-01-05 às 12 01 02" src="https://github.com/storyblok/storyblok-design-system/assets/26799272/5e25876a-bff9-436d-9478-1dbf04319256">

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- add min-height property to sb-icon on the sidebar
- 
- 

## Other information


[ON-1601]: https://storyblok.atlassian.net/browse/ON-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ