### PR TITLE
fix(shape-6): fix sidebar-ideas internal icon

### DIFF
--- a/src/lib/internal-icons.js
+++ b/src/lib/internal-icons.js
@@ -791,7 +791,12 @@ const sidebarIcons = {
   'sidebar-ideas': {
     viewBox: '0 0 24 24',
     path: `
-      <path fill="#fff" d="M10 7a2 2 0 0 1 2-2h7a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-7a2 2 0 0 1-2-2V7Z"/><path fill="#fff" fill-rule="evenodd" d="M6 6a2 2 0 0 0-2 2h4a2 2 0 0 0-2-2Zm2 4H4v5.394a2 2 0 0 0 .336 1.11l.832 1.248a1 1 0 0 0 1.664 0l.832-1.248A2 2 0 0 0 8 15.394V10Z" clip-rule="evenodd" opacity=".57"/><rect width="7" height="2" x="12" y="8" fill="#9DA1AC" rx="1"/><rect width="5" height="2" x="12" y="12" fill="#9DA1AC" rx="1"/>
+      <g fill="none" fill-rule="evenodd">
+        <path fill="currentColor" d="M10 7a2 2 0 0 1 2-2h7a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-7a2 2 0 0 1-2-2V7Z"/>
+        <path fill="currentColor" fill-rule="evenodd" d="M6 6a2 2 0 0 0-2 2h4a2 2 0 0 0-2-2Zm2 4H4v5.394a2 2 0 0 0 .336 1.11l.832 1.248a1 1 0 0 0 1.664 0l.832-1.248A2 2 0 0 0 8 15.394V10Z" clip-rule="evenodd" opacity=".57"/>
+        <rect width="7" height="2" x="12" y="8" fill="#9DA1AC" rx="1"/>
+        <rect width="5" height="2" x="12" y="12" fill="#9DA1AC" rx="1"/>
+      </g>
     `,
   },
   'sidebar-quickstart': {


### PR DESCRIPTION
The color of the sidebar-ideas icon is wrong, now it's always white as if it is selected

<img width="280" alt="Screenshot 2024-01-05 at 09 17 10" src="https://github.com/storyblok/storyblok-design-system/assets/7618411/688354a8-2af8-4d3e-a2c2-0a2ab4f3dc0c">

it should be kind of gray and just turn white on hover or when the item is active like the others


https://github.com/storyblok/storyblok-design-system/assets/7618411/05926610-087b-4448-acb5-45839feb9e7a



## Pull request type

Jira Link: [SHAPE-6](https://storyblok.atlassian.net/browse/SHAPE-6)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- 
- 
- 

## Other information


[SHAPE-6]: https://storyblok.atlassian.net/browse/SHAPE-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ