### PR TITLE
refactor(shape-57): remove the reference to showAvatar data in the SelectInner component

### DIFF
--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -73,7 +73,7 @@
       />
     </div>
 
-    <div v-if="isAvatarVisible && showAvatar" class="sb-select-inner__avatar">
+    <div v-if="isAvatarVisible" class="sb-select-inner__avatar">
       <SbAvatar
         :src="avatarData.src"
         size="small"
@@ -240,10 +240,6 @@ export default {
     'remove-item-value',
   ],
 
-  data: () => ({
-    showAvatar: false,
-  }),
-
   computed: {
     dataTestid() {
       return this.$attrs['data-testid'] || 'sb-select-inner'
@@ -318,8 +314,7 @@ export default {
         this.hasValue &&
         !this.multiple &&
         !this.searchInputText.length &&
-        !this.isAvatarVisible &&
-        !this.showAvatar
+        !this.isAvatarVisible
       )
     },
 
@@ -430,16 +425,6 @@ export default {
   },
 
   watch: {
-    searchInputText(val) {
-      if (
-        this.avatarData &&
-        val === this.avatarData?.label &&
-        this.isAvatarVisible
-      ) {
-        this.showAvatar = true
-      }
-    },
-
     modelValue(val, oldVal) {
       const isSameValue = JSON.stringify(val) === JSON.stringify(oldVal)
       if (this.isSearchTextVisible && !isSameValue) {
@@ -448,14 +433,6 @@ export default {
         }
         return
       }
-
-      if (this.isAvatarVisible) {
-        this.showAvatar = true
-      }
-    },
-
-    isAvatarVisible(val) {
-      this.showAvatar = val
     },
   },
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

This PR should not change anything in the end. When I was testing a component that uses this one I figured out that there was a data variable that seemed not to be necessary. So, this PR removes the reference to it through the code. For testing, you can interact with the SbSelect component and use the option: `use-avatars` that enables the avatars inside the select.

## Other information
