### PR TITLE
fix(shape-9): fix tags count tooltip in the SbSelect

### DIFF
--- a/src/components/Select/components/SelectInner.vue
+++ b/src/components/Select/components/SelectInner.vue
@@ -416,7 +416,7 @@ export default {
     tagsCountTooltip() {
       return {
         label: this.tagLabels
-          ?.map((item) => item.label)
+          ?.map((item) => item[this.itemLabel])
           .slice(1)
           .join(', '),
         position: 'top',


### PR DESCRIPTION
Currently we have a problem with the `tagsCountTooltip`, it does not work when we pass the `itemLabel` prop of the SbSelect

<img width="660" alt="Screenshot 2024-01-14 at 22 54 14" src="https://github.com/storyblok/storyblok-design-system/assets/7618411/faa1f729-58bb-4563-bdd5-ecde172e3082">


## Pull request type

Jira Link: [SHAPE-9](https://storyblok.atlassian.net/browse/SHAPE-9)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

In the SbSelect set the `showCount` prop and select multiples options, it must show a count and when you hover over it should have a tooltip with the names of the tags listed.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Everything must work as before plus should work when passing the `itemLabel` property

## Other information
