### PR TITLE
fix: remove required prop

### DIFF
--- a/src/components/Select/components/SelectInnerTag.vue
+++ b/src/components/Select/components/SelectInnerTag.vue
@@ -71,8 +71,8 @@ export default {
       default: false,
     },
     valueTagCount: {
-      type: String,
-      default: '',
+      type: Number,
+      default: 0,
     },
     isTagAvatarVisible: {
       type: Boolean,
@@ -88,7 +88,7 @@ export default {
     },
     tagsCountTooltip: {
       type: Object,
-      required: true,
+      required: false,
     },
   },
 


### PR DESCRIPTION
Since this prop is only needed under a condition it should be globally required

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!--
Jira Link: [INT-](url)-->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. 

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Nothing should change.

## What is the new behavior?

Since this prop is only needed under a condition it should be globally required as this was throwing a warning in the console for those components that were not using the `showTagCount` option

## Other information
